### PR TITLE
feat: configure CORS from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Auth V1 (Azure Bearer) reste active → séparation claire dans logs :
 - **DB** : Azure MySQL
 - **Backend** : Azure App Service / Container
 - **Monitoring** : Application Insights (présent, warnings dépréciation à gérer)
-- **Secrets** : `.env` → `DATABASE_URL`, `AZURE_CLIENT_ID`, etc.
+- **Secrets** : `.env` → `DATABASE_URL`, `AZURE_CLIENT_ID`, `ALLOWED_ORIGINS`, etc.
 
 ---
 

--- a/src/initializeApp.ts
+++ b/src/initializeApp.ts
@@ -15,18 +15,22 @@ export async function initializeApp() {
 
     app.use(express.json());
 
+    const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",").map(o => o.trim()).filter(Boolean) || [];
+
     // // Configuration CORS globale améliorée
     // app.use(cors(corsConfig));
     //
     // // Middleware pour gérer explicitement les requêtes OPTIONS (preflight)
     // app.options('*', cors(corsConfig));
     app.use((req, res, next) => {
-        const allowedOrigin = 'https://brave-field-03611eb03.5.azurestaticapps.net';
-        const origin = req.headers.origin;
+        const origin = req.headers.origin as string | undefined;
 
-        // Permettre l'origine spécifique ou * en développement
-        if (origin === allowedOrigin || process.env.NODE_ENV === 'development') {
-            res.setHeader('Access-Control-Allow-Origin', origin || '*');
+        if (origin && (allowedOrigins.includes(origin) || process.env.NODE_ENV === 'development')) {
+            res.setHeader('Access-Control-Allow-Origin', origin);
+
+            if (req.headers.authorization || req.headers.cookie) {
+                res.setHeader('Access-Control-Allow-Credentials', 'true');
+            }
         }
 
         res.setHeader('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS');


### PR DESCRIPTION
## Summary
- read allowed origins from `ALLOWED_ORIGINS`
- set CORS headers for matching origins and allow credentials when needed
- document `ALLOWED_ORIGINS` env variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6c097de608330b99f7409874e0b40