### PR TITLE
fix(domain): migrate StockItem and StockSummary properties to camelCase

### DIFF
--- a/src/api/dto/mappers/StockMapper.ts
+++ b/src/api/dto/mappers/StockMapper.ts
@@ -71,12 +71,12 @@ export class StockMapper {
    */
   static itemToDTO(item: StockItem): StockItemDTO {
     return {
-      id: item.ID,
-      label: item.LABEL,
-      description: item.DESCRIPTION,
-      quantity: item.QUANTITY,
+      id: item.id,
+      label: item.label,
+      description: item.description,
+      quantity: item.quantity,
       minimumStock: item.minimumStock,
-      stockId: item.STOCK_ID,
+      stockId: item.stockId,
     };
   }
 

--- a/src/domain/stock-management/common/entities/Stock.ts
+++ b/src/domain/stock-management/common/entities/Stock.ts
@@ -59,7 +59,7 @@ export class Stock {
   }
 
   getTotalQuantity(): number {
-    return this.items.reduce((sum, item) => sum + (item.QUANTITY ?? 0), 0);
+    return this.items.reduce((sum, item) => sum + (item.quantity ?? 0), 0);
   }
 
   addItem(params: {
@@ -77,7 +77,7 @@ export class Stock {
     }
 
     const existingItem = this.items.find(
-      item => item.LABEL.toLowerCase() === params.label.toLowerCase()
+      item => item.label.toLowerCase() === params.label.toLowerCase()
     );
 
     if (existingItem) {
@@ -104,13 +104,13 @@ export class Stock {
       throw new Error('Quantity cannot be negative');
     }
 
-    const item = this.items.find(i => i.ID === itemId);
+    const item = this.items.find(i => i.id === itemId);
 
     if (!item) {
       throw new Error(`Item with ID ${itemId} not found in this stock`);
     }
 
-    item.QUANTITY = quantity;
+    item.quantity = quantity;
   }
 
   getLowStockItems(): StockItem[] {
@@ -122,7 +122,7 @@ export class Stock {
   }
 
   removeItem(itemId: number): void {
-    const index = this.items.findIndex(i => i.ID === itemId);
+    const index = this.items.findIndex(i => i.id === itemId);
 
     if (index === -1) {
       throw new Error(`Item with ID ${itemId} not found in this stock`);
@@ -132,6 +132,6 @@ export class Stock {
   }
 
   getItemById(itemId: number): StockItem | undefined {
-    return this.items.find(i => i.ID === itemId);
+    return this.items.find(i => i.id === itemId);
   }
 }

--- a/src/domain/stock-management/common/entities/StockItem.ts
+++ b/src/domain/stock-management/common/entities/StockItem.ts
@@ -4,14 +4,14 @@ export class StockItem {
   private innerQuantity: Quantity;
 
   constructor(
-    public ID: number,
-    public LABEL: string,
-    public QUANTITY: number,
-    public DESCRIPTION: string,
+    public id: number,
+    public label: string,
+    public quantity: number,
+    public description: string,
     public minimumStock: number = 1,
-    public STOCK_ID: number
+    public stockId: number
   ) {
-    this.innerQuantity = new Quantity(QUANTITY);
+    this.innerQuantity = new Quantity(quantity);
   }
 
   isOutOfStock(): boolean {

--- a/src/domain/stock-management/visualization/models/StockSummary.ts
+++ b/src/domain/stock-management/visualization/models/StockSummary.ts
@@ -1,6 +1,6 @@
 export interface StockSummary {
-  ID: number;
-  LABEL: string;
-  DESCRIPTION: string;
+  id: number;
+  label: string;
+  description: string;
   category: string;
 }

--- a/src/domain/stock-management/visualization/services/StockVisualizationService.ts
+++ b/src/domain/stock-management/visualization/services/StockVisualizationService.ts
@@ -24,9 +24,9 @@ export class StockVisualizationService {
       throw new Error('Stock not found');
     }
     return {
-      ID: stock.id,
-      LABEL: stock.getLabelValue(),
-      DESCRIPTION: stock.getDescriptionValue(),
+      id: stock.id,
+      label: stock.getLabelValue(),
+      description: stock.getDescriptionValue(),
       category: stock.category,
     };
   }

--- a/src/infrastructure/stock-management/manipulation/repositories/PrismaStockCommandRepository.ts
+++ b/src/infrastructure/stock-management/manipulation/repositories/PrismaStockCommandRepository.ts
@@ -28,9 +28,9 @@ export class PrismaStockCommandRepository implements IStockCommandRepository {
           userId: userId,
           items: {
             create: stock.items.map(item => ({
-              label: item.LABEL,
-              description: item.DESCRIPTION,
-              quantity: item.QUANTITY,
+              label: item.label,
+              description: item.description,
+              quantity: item.quantity,
               minimumStock: item.minimumStock,
             })),
           },

--- a/tests/api/controllers/StockControllerVisualization.test.ts
+++ b/tests/api/controllers/StockControllerVisualization.test.ts
@@ -88,9 +88,9 @@ describe('StockControllerVisualization', () => {
         req = { params: { stockId: '1' } };
         mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
         const mockStock = {
-          ID: 1,
-          LABEL: 'Stock 1',
-          DESCRIPTION: 'Description 1',
+          id: 1,
+          label: 'Stock 1',
+          description: 'Description 1',
           category: 'alimentation',
         };
         mockStockService.getStockDetails.mockResolvedValue(mockStock);

--- a/tests/domain/stock-management/common/entities/Stock.test.ts
+++ b/tests/domain/stock-management/common/entities/Stock.test.ts
@@ -127,8 +127,8 @@ describe('Stock', () => {
 
         expect(stock.items).toHaveLength(1);
         expect(stock.items[0]).toBe(item);
-        expect(item.LABEL).toBe('Tomates');
-        expect(item.QUANTITY).toBe(10);
+        expect(item.label).toBe('Tomates');
+        expect(item.quantity).toBe(10);
         expect(item.minimumStock).toBe(3);
       });
     });
@@ -185,9 +185,9 @@ describe('Stock', () => {
 
         const item = stock.addItem(createTestItem());
 
-        stock.updateItemQuantity(item.ID, 25);
+        stock.updateItemQuantity(item.id, 25);
 
-        expect(item.QUANTITY).toBe(25);
+        expect(item.quantity).toBe(25);
       });
     });
 
@@ -197,7 +197,7 @@ describe('Stock', () => {
 
         const item = stock.addItem(createTestItem());
 
-        expect(() => stock.updateItemQuantity(item.ID, -5)).toThrow('Quantity cannot be negative');
+        expect(() => stock.updateItemQuantity(item.id, -5)).toThrow('Quantity cannot be negative');
       });
     });
 
@@ -235,8 +235,8 @@ describe('Stock', () => {
         const lowStockItems = stock.getLowStockItems();
 
         expect(lowStockItems).toHaveLength(2);
-        expect(lowStockItems.map(item => item.LABEL)).toContain('Tomates');
-        expect(lowStockItems.map(item => item.LABEL)).toContain('Pommes');
+        expect(lowStockItems.map(item => item.label)).toContain('Tomates');
+        expect(lowStockItems.map(item => item.label)).toContain('Pommes');
       });
     });
   });

--- a/tests/domain/stock-management/visualization/services/StockVisualizationService.test.ts
+++ b/tests/domain/stock-management/visualization/services/StockVisualizationService.test.ts
@@ -71,9 +71,9 @@ describe('StockVisualizationService', () => {
       it('should return the stock with 0 items and 0 quantity', async () => {
         const result = await service.getStockDetails(1, 1);
         expect(result).toEqual({
-          ID: 1,
-          LABEL: 'Stock 1',
-          DESCRIPTION: 'Description 1',
+          id: 1,
+          label: 'Stock 1',
+          description: 'Description 1',
           category: 'alimentation',
         });
       });
@@ -118,10 +118,10 @@ describe('StockVisualizationService', () => {
       it('should return an array of items', async () => {
         const result = await service.getStockItems(1, 1);
         expect(result.length).toBe(2);
-        expect(result[0].LABEL).toBe('Item 1');
-        expect(result[0].QUANTITY).toBe(5);
-        expect(result[1].LABEL).toBe('Item 2');
-        expect(result[1].QUANTITY).toBe(10);
+        expect(result[0].label).toBe('Item 1');
+        expect(result[0].quantity).toBe(5);
+        expect(result[1].label).toBe('Item 2');
+        expect(result[1].quantity).toBe(10);
       });
     });
   });

--- a/tests/e2e/stock-management/stock-api-workflow.e2e.test.ts
+++ b/tests/e2e/stock-management/stock-api-workflow.e2e.test.ts
@@ -123,9 +123,8 @@ test.describe('Stock Management API E2E Workflow with Azure AD', () => {
     });
 
     const items = await getItemsResponse.json();
-    // V2 returns lowercase field names
-    const apple = items.find((item: any) => (item.label || item.LABEL) === 'Pommes Bio');
-    itemId1 = apple.id || apple.ID;
+    const apple = items.find((item: any) => item.label === 'Pommes Bio');
+    itemId1 = apple.id;
   });
 
   test('Step 3: Add second item to stock (low stock)', async ({ request }) => {
@@ -158,8 +157,7 @@ test.describe('Stock Management API E2E Workflow with Azure AD', () => {
     });
 
     const items = await getItemsResponse.json();
-    // V2 returns lowercase field names
-    items.find((item: any) => (item.label || item.LABEL) === 'Bananes');
+    items.find((item: any) => item.label === 'Bananes');
   });
 
   test('Step 4: Visualize stock and verify items', async ({ request }) => {
@@ -177,18 +175,14 @@ test.describe('Stock Management API E2E Workflow with Azure AD', () => {
     expect(Array.isArray(items)).toBe(true);
     expect(items).toHaveLength(2);
 
-    // V2 returns lowercase field names
-    const apple = items.find((item: any) => (item.label || item.LABEL) === 'Pommes Bio');
-    const banana = items.find((item: any) => (item.label || item.LABEL) === 'Bananes');
+    const apple = items.find((item: any) => item.label === 'Pommes Bio');
+    const banana = items.find((item: any) => item.label === 'Bananes');
 
     expect(apple).toBeDefined();
     expect(banana).toBeDefined();
 
-    const appleQty = apple.quantity || apple.QUANTITY;
-    const bananaQty = banana.quantity || banana.QUANTITY;
-
-    expect(appleQty).toBe(50);
-    expect(bananaQty).toBe(5);
+    expect(apple.quantity).toBe(50);
+    expect(banana.quantity).toBe(5);
   });
 
   test('Step 5: Update item quantity', async ({ request }) => {

--- a/tests/integration/stock-management/repositories/PrismaStockVisualizationRepository.integration.test.ts
+++ b/tests/integration/stock-management/repositories/PrismaStockVisualizationRepository.integration.test.ts
@@ -84,8 +84,8 @@ describe('PrismaStockVisualizationRepository', () => {
         const items = await repo.getStockItems(stock.id, user.id);
 
         expect(items).toHaveLength(1);
-        expect(items[0].LABEL).toBe('Item1');
-        expect(items[0].QUANTITY).toBe(5);
+        expect(items[0].label).toBe('Item1');
+        expect(items[0].quantity).toBe(5);
       });
     });
 


### PR DESCRIPTION
## Contexte

Ferme #86 — migration du code TypeScript v2 vers le camelCase, en cohérence avec la migration Prisma (commit 71e68ec).

## Changements

### Couche Domain
- `StockItem.ts` : renommage des propriétés publiques `ID` → `id`, `LABEL` → `label`, `QUANTITY` → `quantity`, `DESCRIPTION` → `description`, `STOCK_ID` → `stockId`
- `Stock.ts` : mise à jour de tous les accès aux propriétés `StockItem` (recherche par id, update quantity, getLowStockItems)
- `StockSummary.ts` : interface migrée `ID` → `id`, `LABEL` → `label`, `DESCRIPTION` → `description`
- `StockVisualizationService.ts` : `getStockDetails()` retourne désormais `{ id, label, description, category }`

### Couche Infrastructure
- `PrismaStockCommandRepository.ts` : accès `item.LABEL/DESCRIPTION/QUANTITY` → camelCase

### Couche API
- `StockMapper.ts` : `itemToDTO()` lit `item.id/label/description/quantity/stockId`

### Tests
- Tests unitaires domain, API controller et intégration mis à jour
- Tests E2E simplifiés pour les réponses v2 (suppression des fallbacks `item.label || item.LABEL`)

## Périmètre

Le code v1 legacy (`src/repositories/`, `src/controllers/`, `src/models.ts`) conserve ses majuscules — il utilise raw SQL MySQL2 et est hors scope de cette issue.

## Tests

- ✅ 142/142 tests unitaires
- ✅ 0 erreur TypeScript
- ✅ 0 warning ESLint
- ⚙️ Tests d'intégration validés en CI (TestContainers)

## Couches DDD impactées

- Domain : `StockItem`, `Stock`, `StockSummary`, `StockVisualizationService`
- Infrastructure : `PrismaStockCommandRepository`
- API : `StockMapper`