### PR TITLE
feat(api): implement DELETE /api/v2/stocks/:stockId/items/:itemId

### DIFF
--- a/src/api/controllers/StockControllerManipulation.ts
+++ b/src/api/controllers/StockControllerManipulation.ts
@@ -3,6 +3,7 @@ import { AuthenticatedRequest } from '@api/types/AuthenticatedRequest';
 import {
   AddItemToStockRequest,
   CreateStockRequest,
+  DeleteItemRequest,
   DeleteStockRequest,
   UpdateItemQuantityRequest,
   UpdateStockRequest,
@@ -18,6 +19,8 @@ import { AddItemToStockCommand } from '@domain/stock-management/manipulation/com
 import { UpdateItemQuantityCommand } from '@domain/stock-management/manipulation/commands(Request)/UpdateItemQuantityCommand';
 import { UpdateStockCommand } from '@domain/stock-management/manipulation/commands(Request)/UpdateStockCommand';
 import { DeleteStockCommand } from '@domain/stock-management/manipulation/commands(Request)/DeleteStockCommand';
+import { DeleteItemCommand } from '@domain/stock-management/manipulation/commands(Request)/DeleteItemCommand';
+import { DeleteItemCommandHandler } from '@domain/stock-management/manipulation/command-handlers(UseCase)/DeleteItemCommandHandler';
 import { HTTP_CODE_CREATED, HTTP_CODE_OK } from '@utils/httpCodes';
 import { CustomError, sendError } from '@core/errors';
 import { rootMain } from '@utils/logger';
@@ -30,6 +33,7 @@ export class StockControllerManipulation {
     private readonly updateQuantityHandler: UpdateItemQuantityCommandHandler,
     private readonly updateStockHandler: UpdateStockCommandHandler,
     private readonly deleteStockHandler: DeleteStockCommandHandler,
+    private readonly deleteItemHandler: DeleteItemCommandHandler,
     private readonly userService: UserService
   ) {}
 
@@ -142,6 +146,27 @@ export class StockControllerManipulation {
       rootMain.info(`updateStock OID=${OID} stockId=${stockId}`);
 
       res.status(HTTP_CODE_OK).json(stock);
+    } catch (err) {
+      rootException(err as Error);
+      sendError(res, err as CustomError);
+    }
+  }
+
+  public async deleteItem(req: DeleteItemRequest, res: express.Response) {
+    try {
+      const OID = this.getValidatedOID(req, res);
+      if (!OID) return;
+
+      const stockId = Number(req.params.stockId);
+      const itemId = Number(req.params.itemId);
+
+      const command = new DeleteItemCommand(stockId, itemId);
+
+      await this.deleteItemHandler.handle(command);
+
+      rootMain.info(`deleteItem OID=${OID} stockId=${stockId} itemId=${itemId}`);
+
+      res.status(204).send();
     } catch (err) {
       rootException(err as Error);
       sendError(res, err as CustomError);

--- a/src/api/routes/StockRoutesV2.ts
+++ b/src/api/routes/StockRoutesV2.ts
@@ -5,6 +5,7 @@ import { StockControllerManipulation } from '@api/controllers/StockControllerMan
 import {
   AddItemToStockRequest,
   CreateStockRequest,
+  DeleteItemRequest,
   DeleteStockRequest,
   UpdateItemQuantityRequest,
   UpdateStockRequest,
@@ -19,6 +20,7 @@ import { AddItemToStockCommandHandler } from '@domain/stock-management/manipulat
 import { UpdateItemQuantityCommandHandler } from '@domain/stock-management/manipulation/command-handlers(UseCase)/UpdateItemQuantityCommandHandler';
 import { UpdateStockCommandHandler } from '@domain/stock-management/manipulation/command-handlers(UseCase)/UpdateStockCommandHandler';
 import { DeleteStockCommandHandler } from '@domain/stock-management/manipulation/command-handlers(UseCase)/DeleteStockCommandHandler';
+import { DeleteItemCommandHandler } from '@domain/stock-management/manipulation/command-handlers(UseCase)/DeleteItemCommandHandler';
 import { rootController } from '@utils/logger';
 import { PrismaClient } from '@prisma/client';
 import { authorizeStockRead, authorizeStockWrite } from '@authorization/authorizeMiddleware';
@@ -42,6 +44,7 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
   const updateQuantityHandler = new UpdateItemQuantityCommandHandler(commandRepository);
   const updateStockHandler = new UpdateStockCommandHandler(commandRepository);
   const deleteStockHandler = new DeleteStockCommandHandler(commandRepository);
+  const deleteItemHandler = new DeleteItemCommandHandler(commandRepository);
 
   const manipulationController = new StockControllerManipulation(
     createStockHandler,
@@ -49,6 +52,7 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
     updateQuantityHandler,
     updateStockHandler,
     deleteStockHandler,
+    deleteItemHandler,
     userService
   );
 
@@ -110,6 +114,16 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
   });
 
   logger.info('Routes for PATCH /stocks/:stockId configured');
+
+  router.delete(
+    STOCK_ROUTES.DELETE_ITEM,
+    authorizeStockWrite,
+    async (req, res: express.Response) => {
+      await manipulationController.deleteItem(req as DeleteItemRequest, res);
+    }
+  );
+
+  logger.info('Routes for DELETE /stocks/:stockId/items/:itemId configured (with authorization)');
 
   router.delete('/stocks/:stockId', async (req, res: express.Response) => {
     await manipulationController.deleteStock(req as DeleteStockRequest, res);

--- a/src/api/routes/constants/routePaths.ts
+++ b/src/api/routes/constants/routePaths.ts
@@ -20,4 +20,7 @@ export const STOCK_ROUTES = {
 
   /** PATCH - Update item quantity (requires write permission) */
   UPDATE_ITEM_QUANTITY: '/stocks/:stockId/items/:itemId',
+
+  /** DELETE - Remove an item from a stock (requires write permission) */
+  DELETE_ITEM: '/stocks/:stockId/items/:itemId',
 } as const;

--- a/src/api/types/StockRequestTypes.ts
+++ b/src/api/types/StockRequestTypes.ts
@@ -69,3 +69,5 @@ export type UpdateItemQuantityRequest = AuthenticatedRequest<
 export type UpdateStockRequest = AuthenticatedRequest<StockParams, unknown, UpdateStockBody>;
 
 export type DeleteStockRequest = AuthenticatedRequest<StockParams, unknown, unknown>;
+
+export type DeleteItemRequest = AuthenticatedRequest<StockItemParams, unknown, unknown>;

--- a/src/domain/stock-management/manipulation/command-handlers(UseCase)/DeleteItemCommandHandler.ts
+++ b/src/domain/stock-management/manipulation/command-handlers(UseCase)/DeleteItemCommandHandler.ts
@@ -1,0 +1,22 @@
+import { DeleteItemCommand } from '@domain/stock-management/manipulation/commands(Request)/DeleteItemCommand';
+import { IStockCommandRepository } from '@domain/stock-management/manipulation/repositories/IStockCommandRepository';
+
+export class DeleteItemCommandHandler {
+  constructor(private readonly stockRepository: IStockCommandRepository) {}
+
+  async handle(command: DeleteItemCommand): Promise<void> {
+    const stock = await this.stockRepository.findById(command.stockId);
+
+    if (!stock) {
+      throw new Error(`Stock with ID ${command.stockId} not found`);
+    }
+
+    const item = stock.getItemById(command.itemId);
+
+    if (!item) {
+      throw new Error(`Item with ID ${command.itemId} not found in stock ${command.stockId}`);
+    }
+
+    await this.stockRepository.deleteItem(command.stockId, command.itemId);
+  }
+}

--- a/src/domain/stock-management/manipulation/commands(Request)/DeleteItemCommand.ts
+++ b/src/domain/stock-management/manipulation/commands(Request)/DeleteItemCommand.ts
@@ -1,0 +1,6 @@
+export class DeleteItemCommand {
+  constructor(
+    public readonly stockId: number,
+    public readonly itemId: number
+  ) {}
+}

--- a/src/domain/stock-management/manipulation/repositories/IStockCommandRepository.ts
+++ b/src/domain/stock-management/manipulation/repositories/IStockCommandRepository.ts
@@ -22,4 +22,5 @@ export interface IStockCommandRepository {
     }
   ): Promise<Stock>;
   deleteStock(stockId: number): Promise<void>;
+  deleteItem(stockId: number, itemId: number): Promise<void>;
 }

--- a/src/infrastructure/stock-management/manipulation/repositories/PrismaStockCommandRepository.ts
+++ b/src/infrastructure/stock-management/manipulation/repositories/PrismaStockCommandRepository.ts
@@ -278,6 +278,31 @@ export class PrismaStockCommandRepository implements IStockCommandRepository {
     }
   }
 
+  async deleteItem(stockId: number, itemId: number): Promise<void> {
+    let success = false;
+
+    try {
+      await this.prisma.item.delete({
+        where: { id: itemId, stockId: stockId },
+      });
+
+      success = true;
+    } catch (error) {
+      rootException(error as Error);
+      throw error;
+    } finally {
+      rootDependency({
+        name: DEPENDENCY_NAME,
+        data: `prisma.item.delete({ where: {id: ${itemId}, stockId: ${stockId}} })`,
+        duration: 0,
+        success: success,
+        resultCode: 0,
+        target: DEPENDENCY_TARGET,
+        dependencyTypeName: DEPENDENCY_TYPE,
+      } as DependencyTelemetry);
+    }
+  }
+
   private normalizeCategory(category: string | StockCategory): StockCategory {
     const lowerCategory = category.toLowerCase();
     const categoryValues = Object.values(StockCategory);

--- a/tests/api/controllers/StockControllerManipulation.test.ts
+++ b/tests/api/controllers/StockControllerManipulation.test.ts
@@ -47,12 +47,17 @@ describe('StockControllerManipulation', () => {
       handle: jest.fn(),
     };
 
+    const mockDeleteItemHandler: any = {
+      handle: jest.fn(),
+    };
+
     controller = new StockControllerManipulation(
       mockCreateStockHandler,
       mockAddItemHandler,
       mockUpdateQuantityHandler,
       mockUpdateStockHandler,
       mockDeleteStockHandler,
+      mockDeleteItemHandler,
       mockUserService
     );
 

--- a/tests/domain/stock-management/manipulation/command-handlers/AddItemToStockCommandHandler.test.ts
+++ b/tests/domain/stock-management/manipulation/command-handlers/AddItemToStockCommandHandler.test.ts
@@ -18,6 +18,7 @@ describe('AddItemToStockCommandHandler', () => {
           updateItemQuantity: jest.fn(),
           updateStock: jest.fn(),
           deleteStock: jest.fn(),
+          deleteItem: jest.fn(),
         };
 
         const handler = new AddItemToStockCommandHandler(mockRepository);

--- a/tests/domain/stock-management/manipulation/command-handlers/CreateStockCommandHandler.test.ts
+++ b/tests/domain/stock-management/manipulation/command-handlers/CreateStockCommandHandler.test.ts
@@ -16,6 +16,7 @@ describe('CreateStockCommandHandler', () => {
           updateItemQuantity: jest.fn(),
           updateStock: jest.fn(),
           deleteStock: jest.fn(),
+          deleteItem: jest.fn(),
         };
 
         const handler = new CreateStockCommandHandler(mockRepository);

--- a/tests/domain/stock-management/manipulation/command-handlers/DeleteItemCommandHandler.test.ts
+++ b/tests/domain/stock-management/manipulation/command-handlers/DeleteItemCommandHandler.test.ts
@@ -1,0 +1,75 @@
+import { DeleteItemCommandHandler } from '@domain/stock-management/manipulation/command-handlers(UseCase)/DeleteItemCommandHandler';
+import { DeleteItemCommand } from '@domain/stock-management/manipulation/commands(Request)/DeleteItemCommand';
+import { IStockCommandRepository } from '@domain/stock-management/manipulation/repositories/IStockCommandRepository';
+import { Stock } from '@domain/stock-management/common/entities/Stock';
+import { StockItem } from '@domain/stock-management/common/entities/StockItem';
+
+describe('DeleteItemCommandHandler', () => {
+  describe('handle()', () => {
+    const createMockRepository = (
+      overrides: Partial<IStockCommandRepository> = {}
+    ): IStockCommandRepository => ({
+      save: jest.fn(),
+      findById: jest.fn(),
+      addItemToStock: jest.fn(),
+      updateItemQuantity: jest.fn(),
+      updateStock: jest.fn(),
+      deleteStock: jest.fn(),
+      deleteItem: jest.fn(),
+      ...overrides,
+    });
+
+    describe('when stock and item exist', () => {
+      it('should call deleteItem on the repository', async () => {
+        const item = new StockItem(1, 'Tomates', 10, 'Tomates fraîches', 2, 1);
+        const mockStock = new Stock(1, 'Stock Cuisine', 'Description', 'alimentation', [item]);
+
+        const mockRepository = createMockRepository({
+          findById: jest.fn().mockResolvedValue(mockStock),
+          deleteItem: jest.fn().mockResolvedValue(undefined),
+        });
+
+        const handler = new DeleteItemCommandHandler(mockRepository);
+        const command = new DeleteItemCommand(1, 1);
+
+        await handler.handle(command);
+
+        expect(mockRepository.findById).toHaveBeenCalledWith(1);
+        expect(mockRepository.deleteItem).toHaveBeenCalledWith(1, 1);
+      });
+    });
+
+    describe('when stock does not exist', () => {
+      it('should throw an error', async () => {
+        const mockRepository = createMockRepository({
+          findById: jest.fn().mockResolvedValue(null),
+        });
+
+        const handler = new DeleteItemCommandHandler(mockRepository);
+        const command = new DeleteItemCommand(99, 1);
+
+        await expect(handler.handle(command)).rejects.toThrow('Stock with ID 99 not found');
+        expect(mockRepository.deleteItem).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when item does not exist in the stock', () => {
+      it('should throw an error', async () => {
+        const item = new StockItem(1, 'Tomates', 10, 'Tomates fraîches', 2, 1);
+        const mockStock = new Stock(1, 'Stock Cuisine', 'Description', 'alimentation', [item]);
+
+        const mockRepository = createMockRepository({
+          findById: jest.fn().mockResolvedValue(mockStock),
+        });
+
+        const handler = new DeleteItemCommandHandler(mockRepository);
+        const command = new DeleteItemCommand(1, 99);
+
+        await expect(handler.handle(command)).rejects.toThrow(
+          'Item with ID 99 not found in stock 1'
+        );
+        expect(mockRepository.deleteItem).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/tests/domain/stock-management/manipulation/command-handlers/UpdateItemQuantityCommandHandler.test.ts
+++ b/tests/domain/stock-management/manipulation/command-handlers/UpdateItemQuantityCommandHandler.test.ts
@@ -18,6 +18,7 @@ describe('UpdateItemQuantityCommandHandler', () => {
           updateItemQuantity: jest.fn().mockResolvedValue(mockStock),
           updateStock: jest.fn(),
           deleteStock: jest.fn(),
+          deleteItem: jest.fn(),
         };
 
         const handler = new UpdateItemQuantityCommandHandler(mockRepository);
@@ -42,6 +43,7 @@ describe('UpdateItemQuantityCommandHandler', () => {
           updateItemQuantity: jest.fn().mockResolvedValue(mockStock),
           updateStock: jest.fn(),
           deleteStock: jest.fn(),
+          deleteItem: jest.fn(),
         };
 
         const handler = new UpdateItemQuantityCommandHandler(mockRepository);


### PR DESCRIPTION
## Contexte

Ferme #90 — endpoint manquant identifié lors des tests Postman en staging.

> ⚠️ Cette PR est basée sur `fix-issue-86-stockitem-lowercase` (PR #91). À merger après #91 pour éviter les conflits, ou rebaser sur `main` une fois #91 mergé.

## Changements

### Couche Domain
- `DeleteItemCommand.ts` — commande avec `stockId` et `itemId`
- `DeleteItemCommandHandler.ts` — vérifie l'existence du stock et de l'item avant suppression
- `IStockCommandRepository.ts` — ajout de `deleteItem(stockId, itemId): Promise<void>`

### Couche Infrastructure
- `PrismaStockCommandRepository.ts` — implémentation `prisma.item.delete({ where: { id, stockId } })`

### Couche API
- `StockControllerManipulation.ts` — méthode `deleteItem()`, retourne 204 No Content
- `StockRequestTypes.ts` — type `DeleteItemRequest`
- `routePaths.ts` — constante `DELETE_ITEM`
- `StockRoutesV2.ts` — route `DELETE /stocks/:stockId/items/:itemId` avec `authorizeStockWrite`

### Tests
- `DeleteItemCommandHandler.test.ts` — 3 cas : succès, stock inexistant, item inexistant
- Mocks `IStockCommandRepository` mis à jour dans tous les tests existants

## Comportement

| Cas | Réponse |
|---|---|
| Suppression réussie | `204 No Content` |
| Stock ou item inexistant | `404 Not Found` |
| Droits insuffisants (< EDITOR) | `403 Forbidden` |

## Tests

- ✅ 145/145 tests unitaires
- ✅ 0 erreur TypeScript
- ✅ 0 warning ESLint

## Couches DDD impactées

- Domain : `DeleteItemCommand`, `DeleteItemCommandHandler`, `IStockCommandRepository`
- Infrastructure : `PrismaStockCommandRepository`
- API : `StockControllerManipulation`, `StockRoutesV2`