### PR TITLE
fix(security): add authorizeStockWrite on PATCH and DELETE stock routes

### DIFF
--- a/src/api/routes/StockRoutesV2.ts
+++ b/src/api/routes/StockRoutesV2.ts
@@ -109,11 +109,11 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
 
   logger.info('Routes for PATCH /stocks/:stockId/items/:itemId configured (with authorization)');
 
-  router.patch('/stocks/:stockId', async (req, res: express.Response) => {
+  router.patch('/stocks/:stockId', authorizeStockWrite, async (req, res: express.Response) => {
     await manipulationController.updateStock(req as UpdateStockRequest, res);
   });
 
-  logger.info('Routes for PATCH /stocks/:stockId configured');
+  logger.info('Routes for PATCH /stocks/:stockId configured (with authorization)');
 
   router.delete(
     STOCK_ROUTES.DELETE_ITEM,
@@ -125,11 +125,11 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
 
   logger.info('Routes for DELETE /stocks/:stockId/items/:itemId configured (with authorization)');
 
-  router.delete('/stocks/:stockId', async (req, res: express.Response) => {
+  router.delete('/stocks/:stockId', authorizeStockWrite, async (req, res: express.Response) => {
     await manipulationController.deleteStock(req as DeleteStockRequest, res);
   });
 
-  logger.info('Routes for DELETE /stocks/:stockId configured');
+  logger.info('Routes for DELETE /stocks/:stockId configured (with authorization)');
 
   return router;
 };


### PR DESCRIPTION
## 🔗 Issue liée

Closes #98

## 📋 Description

Correction d'une vulnérabilité OWASP A01 Broken Access Control : les routes `PATCH /api/v2/stocks/:stockId` et `DELETE /api/v2/stocks/:stockId` n'avaient pas le middleware `authorizeStockWrite`, permettant à tout utilisateur authentifié de modifier ou supprimer le stock d'un autre utilisateur.

## 🔧 Détails d'implémentation

Couche impactée : **PRESENTATION** (`src/api/routes/StockRoutesV2.ts`)

Pattern suivi : identique aux autres routes protégées en écriture (ex: `POST /stocks/:stockId/items`, `PATCH /stocks/:stockId/items/:itemId`, `DELETE /stocks/:stockId/items/:itemId`).

```typescript
// Avant
router.patch('/stocks/:stockId', async (req, res) => { ... });
router.delete('/stocks/:stockId', async (req, res) => { ... });

// Après
router.patch('/stocks/:stockId', authorizeStockWrite, async (req, res) => { ... });
router.delete('/stocks/:stockId', authorizeStockWrite, async (req, res) => { ... });
```

ADR lié : `docs/adr/ADR-009-resource-based-authorization.md`

## 🧪 Type de changement

- [ ] ✨ Nouvelle fonctionnalité (feat)
- [x] 🐛 Correction de bug (fix)
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] ⚙️ CI/CD / Config (chore, ci, build)

## ✅ Checklist

### Tests

- [x] Tests unitaires passent (`npm run test:unit`) — 145 tests
- [ ] Tests d'intégration passent (`npm run test:integration`)
- [x] Build réussit (`npm run build`)

### Qualité

- [x] Titre PR suit le format Conventional Commits
- [x] ESLint 0 warnings (`npm run lint`)
- [x] TypeScript 0 erreurs — pas de `as` non justifié
- [x] Pas de `console.*` — logging structuré utilisé
- [x] Pas de secrets exposés dans le code

### Documentation

- [ ] OpenAPI mis à jour si nouvel endpoint (`docs/openapi.yaml`)
- [ ] ADR créé si décision architecturale importante (`docs/adr/`)
- [x] GitHub Project mis à jour

## ❓ Points à surveiller / Questions

Critère RNCP Ce2.4 #4 #6 — OWASP A01 Broken Access Control corrigé.