### PR TITLE
fix(tests): add coverageThreshold 80% and update README metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ![CI/CD Pipeline](https://github.com/sandrineCipolla/stockhub_back/actions/workflows/main_stockhub-back.yml/badge.svg)
 ![Security Audit](https://github.com/SandrineCipolla/stockhub_back/actions/workflows/security-audit.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-2.4.0-blue)
-![Node](https://img.shields.io/badge/node-20.x-brightgreen)
+![Version](https://img.shields.io/badge/version-2.5.0-blue)
+![Node](https://img.shields.io/badge/node-22.x-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)
+![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen)
 
 StockHub est une application web conçue pour aider les familles à gérer leurs stocks de produits (alimentaires, artistiques...).
 Elle permet aux utilisateurs de visualiser l'état des stocks et de les mettre à jour facilement.
@@ -249,7 +250,7 @@ npx prisma migrate deploy # Appliquer les migrations
 npx prisma studio        # Interface visuelle DB
 
 # Tests
-npm run test:unit        # 142 tests unitaires
+npm run test:unit        # 145 tests unitaires
 npm run test:integration # Tests d'intégration (TestContainers)
 npm run test:e2e         # Tests E2E Playwright
 npm run test:coverage    # Rapport de couverture
@@ -267,6 +268,9 @@ npm run azure:stop       # Arrêter l'app Azure après les tests
 ## 8. Tests
 
 ### Unitaires (TDD)
+
+**145 tests — couverture globale : 92% statements | 82% branches | 94% functions**
+Seuil minimum configuré : 80% sur toutes les métriques (`jest.ci.config.js`)
 
 - `Quantity` : valeurs invalides interdites
 - `StockItem` : `isOutOfStock()`, `isLowStock()`

--- a/jest.ci.config.js
+++ b/jest.ci.config.js
@@ -37,4 +37,12 @@ module.exports = {
     '!<rootDir>/tests/**', // Exclure les tests d'intégration
     '!<rootDir>/src/**/*.d.ts', // Exclure les fichiers de types (déclaration .d.ts)
   ],
+  coverageThreshold: {
+    global: {
+      statements: 80,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+    },
+  },
 };


### PR DESCRIPTION
## Résumé

- Ajoute `coverageThreshold` (80% statements/branches/functions/lines) dans `jest.ci.config.js` — le CI échoue si la couverture descend sous ce seuil
- Met à jour le README : couverture actuelle (92% statements, 82% branches, 94% functions, 145 tests), badge Node 22, version 2.5.0

## Couverture actuelle (mesurée)

| Métrique   | Actuel | Seuil |
|------------|--------|-------|
| Statements | 92.88% | 80%   |
| Branches   | 82.11% | 80%   |
| Functions  | 94.94% | 80%   |
| Lines      | 92.88% | 80%   |

## Lien

Closes #99