### PR TITLE
docs: add .env.example for local development setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# =============================================================
+# StockHub Backend — Variables d'environnement (exemple)
+# =============================================================
+# Copier ce fichier en .env et remplir les valeurs réelles
+# NE JAMAIS committer .env (gitignored)
+# =============================================================
+
+NODE_ENV=development
+
+# --- Base de données MySQL ---
+# Local Docker : port 3308 (voir compose.yaml)
+# Staging Aiven : ajouter ?ssl-mode=REQUIRED à la fin
+DATABASE_URL=mysql://root:password@localhost:3308/stockhub
+
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=password
+DB_PORT=3308
+DB_DATABASE=stockhub
+DB_SSL=false
+DB_CONNECTION_LIMIT=10
+DB_MAX_IDLE=3
+
+# --- Azure AD B2C ---
+# CLIENT_ID : application PKCE (frontend + validation tokens Bearer entrants)
+# AZURE_ROPC_CLIENT_ID : application ROPC (tests E2E Playwright + Postman)
+CLIENT_ID=your-azure-ad-b2c-client-id
+AZURE_USE_ROPC_POLICY=false
+AZURE_ROPC_CLIENT_ID=your-ropc-client-id
+
+# --- CORS ---
+# Liste des origines autorisées, séparées par des virgules
+ALLOWED_ORIGINS=http://localhost:5173
+# Activer le CORS pour les previews Vercel (staging uniquement)
+VERCEL_PREVIEW_CORS=false
+
+# --- Application Insights (optionnel — prod/staging uniquement) ---
+# Laisser vide en local pour désactiver le monitoring Azure
+APPLICATIONINSIGHTS_CONNECTION_STRING=
+
+# --- Serveur ---
+PORT=3006
+
+# --- Seed (prisma/seed.ts) ---
+# Email de l'utilisateur owner dans Azure AD B2C
+SEED_OWNER_EMAIL=your-owner-email@example.com


### PR DESCRIPTION
## Résumé

Ajoute `.env.example` à la racine du projet avec toutes les variables d'environnement requises et des valeurs placeholder documentées.

Couvre : base de données MySQL, Azure AD B2C (PKCE + ROPC), CORS, Application Insights, port serveur, seed.

## Pourquoi

Le `.env` est gitignored. Sans `.env.example`, un nouveau contributeur qui clone le repo ne sait pas quelles variables configurer. Ce fichier sert de référence commité.

Note : `.env.staging.example` existe déjà pour Render — ce fichier couvre le développement local.

## Lien

Closes #100