### PR TITLE
refactor(domain): extract StockCategory enum to domain layer

### DIFF
--- a/src/domain/stock-management/common/entities/Stock.ts
+++ b/src/domain/stock-management/common/entities/Stock.ts
@@ -1,7 +1,7 @@
 import { StockLabel } from '@domain/stock-management/common/value-objects/StockLabel';
 import { StockDescription } from '@domain/stock-management/common/value-objects/StockDescription';
 import { Quantity } from '@domain/stock-management/common/value-objects/Quantity';
-import { StockCategory } from '@prisma/client';
+import { StockCategory } from '@domain/stock-management/common/enums/StockCategory';
 import { StockItem } from '@domain/stock-management/common/entities/StockItem';
 
 export class Stock {

--- a/src/domain/stock-management/common/enums/StockCategory.ts
+++ b/src/domain/stock-management/common/enums/StockCategory.ts
@@ -1,0 +1,5 @@
+export enum StockCategory {
+  alimentation = 'alimentation',
+  hygiene = 'hygiene',
+  artistique = 'artistique',
+}


### PR DESCRIPTION
## Résumé

Crée `src/domain/stock-management/common/enums/StockCategory.ts` avec les 3 valeurs (`alimentation`, `hygiene`, `artistique`) et met à jour `Stock.ts` pour importer depuis le domain au lieu de `@prisma/client`.

## Violation DDD corrigée

`Stock.ts` (couche domain) importait `StockCategory` depuis `@prisma/client` (couche infrastructure), violant la règle de dépendance DDD :

```
// Avant — violation
import { StockCategory } from '@prisma/client';

// Après — conforme
import { StockCategory } from '@domain/stock-management/common/enums/StockCategory';
```

`PrismaStockCommandRepository.ts` (infrastructure) conserve son import Prisma pour les opérations DB — c'est le comportement attendu.

## Vérifications

- `tsc --noEmit` ✅
- 145 tests unitaires ✅

## Lien

Closes #103