### PR TITLE
docs(adr): add ADR-011 (Render+Aiven staging) and ADR-012 (Node.js 22)

### DIFF
--- a/docs/adr/ADR-011-staging-render-aiven.md
+++ b/docs/adr/ADR-011-staging-render-aiven.md
@@ -1,0 +1,76 @@
+# ADR-011: Choix de Render.com + Aiven MySQL pour le staging
+
+**Date:** 2026-01-15
+**Statut:** Accepté
+**Décideurs:** Sandrine Cipolla
+
+---
+
+## Contexte
+
+Le projet nécessite un environnement de staging pour :
+
+- Valider les déploiements avant la production Azure
+- Exécuter les tests E2E Playwright dans un environnement réel
+- Permettre des démonstrations sans impacter la production
+
+### Contraintes
+
+- Budget : gratuit (certification RNCP, projet personnel)
+- Base de données : MySQL (compatible avec le schéma Prisma existant)
+- Déploiement : automatisable via GitHub Actions
+- Hébergement : doit supporter Node.js avec Webpack build
+
+---
+
+## Décision
+
+**Render.com** pour l'hébergement de l'application Node.js et **Aiven MySQL** (free tier) pour la base de données staging.
+
+### Configuration
+
+- `render.yaml` à la racine définit le service (`startCommand: node dist/index.js`)
+- `autoDeploy: false` — déploiement déclenché manuellement via hook curl dans GitHub Actions
+- Branche deployée : `main`
+- Aiven MySQL : connexion avec `DB_SSL=true` et `?ssl-mode=REQUIRED` dans `DATABASE_URL`
+
+---
+
+## Raisons
+
+| Critère         | Render.com          | Aiven MySQL              |
+| --------------- | ------------------- | ------------------------ |
+| Coût            | Gratuit (750h/mois) | Gratuit (free tier)      |
+| Support Node.js | Natif               | —                        |
+| Support MySQL   | —                   | Natif, compatible Prisma |
+| Déploiement CI  | Hook curl           | —                        |
+| Localisation    | US (EU possible)    | EU (RGPD)                |
+
+---
+
+## Alternatives considérées
+
+| Alternative           | Raison du rejet                                                    |
+| --------------------- | ------------------------------------------------------------------ |
+| **Railway**           | Free tier supprimé en 2023                                         |
+| **Fly.io**            | Configuration plus complexe, Docker requis                         |
+| **PlanetScale**       | MySQL-compatible mais branching model inadapté, free tier supprimé |
+| **Heroku**            | Plus gratuit depuis 2022                                           |
+| **Staging sur Azure** | Coût supplémentaire, quota F1 déjà limité en prod                  |
+
+---
+
+## Conséquences
+
+### Positives
+
+- Environnement staging fonctionnel sans coût
+- Pipeline CI/CD complet (dev → staging → prod)
+- Tests E2E Playwright sur environnement réel avant prod
+
+### Négatives
+
+- **Aiven free tier** : instance MySQL se met en veille après inactivité — nécessite un "Power on" manuel via console.aiven.io
+- **Render.com cold start** : ~30s de démarrage après inactivité (free tier)
+- **Render US** : latence légèrement plus élevée depuis l'EU
+- Procédure documentée : `docs/troubleshooting/staging-render-issues.md`

--- a/docs/adr/ADR-012-upgrade-node-22.md
+++ b/docs/adr/ADR-012-upgrade-node-22.md
@@ -1,0 +1,74 @@
+# ADR-012: Migration vers Node.js 22 LTS
+
+**Date:** 2026-03-10
+**Statut:** Accepté
+**Décideurs:** Sandrine Cipolla
+
+---
+
+## Contexte
+
+Le projet utilisait Node.js 20 LTS (fin de support actif : octobre 2026, fin de maintenance : avril 2026).
+
+Node.js 22 est entré en phase **LTS active** en octobre 2024 avec un support garanti jusqu'en avril 2027, et maintenance jusqu'en avril 2028.
+
+### Périmètre de la migration
+
+- `Dockerfile` : image de base `node:22-alpine`
+- `.github/workflows/ci.yml` : `node-version: '22.x'`
+- `render.yaml` : `nodeVersion: 22`
+- `.nvmrc` : version locale `22`
+
+---
+
+## Décision
+
+Migrer de **Node.js 20** vers **Node.js 22 LTS** sur tous les environnements (local, CI, staging, production).
+
+---
+
+## Raisons
+
+| Critère                   | Node.js 20               | Node.js 22             |
+| ------------------------- | ------------------------ | ---------------------- |
+| Statut LTS                | Maintenance (→ avr 2026) | Actif (→ avr 2027)     |
+| V8 Engine                 | V8 11.3                  | V8 12.4                |
+| Performance               | Référence                | +~10% selon benchmarks |
+| `fetch` natif             | Expérimental             | Stable                 |
+| Support Azure App Service | ✅                       | ✅                     |
+
+### Cohérence des environnements
+
+La règle Ce3.5 #22 exige des environnements homogènes. Mettre à jour tous les points de configuration simultanément garantit que CI, staging et prod tournent exactement sur la même version.
+
+---
+
+## Alternatives considérées
+
+| Alternative                | Raison du rejet                                                   |
+| -------------------------- | ----------------------------------------------------------------- |
+| **Rester sur Node.js 20**  | Fin de support maintenance avril 2026, dette technique croissante |
+| **Migrer vers Node.js 23** | Version Current, pas LTS — instabilité et support court           |
+| **Migrer progressivement** | Risque de divergence entre environnements                         |
+
+---
+
+## Conséquences
+
+### Positives
+
+- Environnements uniformes sur Node.js 22 LTS (local, CI, staging, prod)
+- Support garanti jusqu'en avril 2028
+- Accès aux dernières améliorations de performance V8
+- `fetch` natif stable (supprime le besoin de `node-fetch` si utilisé)
+
+### Négatives
+
+- Risque de breaking changes dans les dépendances natives — validé par `npm audit` et CI sans erreur
+- Mise à jour requise sur tous les environnements simultanément (réalisée dans PR #105)
+
+### Validation
+
+- Tests unitaires (145 tests) : ✅ passent sur Node.js 22
+- Pipeline CI GitHub Actions : ✅
+- Build Webpack : ✅

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -27,6 +27,8 @@ Un ADR (Architecture Decision Record) est un document qui capture une **décisio
 | [ADR-008](./ADR-008-typescript-request-type-aliases.md) | Type Aliases pour requêtes Express           | 2025-12-26 | ✅ Accepté |
 | [ADR-009](./ADR-009-resource-based-authorization.md)    | Système d'autorisation hybride (Phase 1 ✅)  | 2025-12-27 | ✅ Accepté |
 | [ADR-010](./ADR-010-ci-cd-pipeline-optimization.md)     | Optimisation pipeline CI/CD GitHub Actions   | 2025-12-27 | ✅ Accepté |
+| [ADR-011](./ADR-011-staging-render-aiven.md)            | Staging Render.com + Aiven MySQL             | 2026-01-15 | ✅ Accepté |
+| [ADR-012](./ADR-012-upgrade-node-22.md)                 | Migration vers Node.js 22 LTS                | 2026-03-10 | ✅ Accepté |
 
 ## 📖 Comment lire un ADR ?
 
@@ -122,5 +124,5 @@ Si une décision change :
 
 ---
 
-**Dernière mise à jour** : 2026-01-27
+**Dernière mise à jour** : 2026-03-10
 **Mainteneur** : Équipe StockHub Backend


### PR DESCRIPTION
## Résumé

Documente deux décisions architecturales non encore formalisées en ADR.

### ADR-011 — Staging Render.com + Aiven MySQL

Justifie le choix de Render.com pour l'hébergement staging et Aiven MySQL pour la base de données, avec les alternatives rejetées (Railway, Fly.io, PlanetScale, Heroku, Azure staging) et les trade-offs (cold start, mise en veille Aiven).

### ADR-012 — Migration Node.js 22 LTS

Documente la migration de Node.js 20 vers Node.js 22 LTS (PR #105), couvrant tous les points de configuration : Dockerfile, CI workflow, render.yaml, .nvmrc.

## Lien

Closes #104