### PR TITLE
docs(openapi): update PATCH items to reflect full UpdateItem command

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,7 @@ Thumbs.db
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+# Postman collections (large JSON files not suited for Prettier formatting)
+*.postman_collection.json
+postman/

--- a/Stockhub_V2.postman_collection.json
+++ b/Stockhub_V2.postman_collection.json
@@ -1,0 +1,303 @@
+{
+  "info": {
+    "name": "Stockhub API V2",
+    "_postman_id": "12345678-abcd-efgh-ijkl-1234567890ab",
+    "description": "Collection pour tester les endpoints /api/v2.\n\nAuth : ROPC (username/password → token automatique)\n1. Renseigner username et password dans l'environnement actif\n2. Lancer '🔑 Get Token' → le token est sauvegardé dans accessToken\n3. Toutes les requêtes utilisent automatiquement ce token\n\nCatégories valides : alimentation | hygiene | artistique",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "stockId",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "itemId",
+      "value": "1",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "🔑 Get Token",
+      "request": {
+        "auth": { "type": "noauth" },
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/x-www-form-urlencoded" }],
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            { "key": "grant_type", "value": "password" },
+            { "key": "client_id", "value": "a6a645f0-32fe-42cc-b524-6a3d83bbfb43" },
+            { "key": "username", "value": "{{username}}" },
+            { "key": "password", "value": "{{password}}" },
+            {
+              "key": "scope",
+              "value": "https://stockhubb2c.onmicrosoft.com/a6a645f0-32fe-42cc-b524-6a3d83bbfb43/access_as_user"
+            },
+            { "key": "response_type", "value": "token" }
+          ]
+        },
+        "url": {
+          "raw": "https://stockhubb2c.b2clogin.com/stockhubb2c.onmicrosoft.com/B2C_1_ROPC/oauth2/v2.0/token",
+          "protocol": "https",
+          "host": ["stockhubb2c.b2clogin.com"],
+          "path": ["stockhubb2c.onmicrosoft.com", "B2C_1_ROPC", "oauth2", "v2.0", "token"]
+        },
+        "description": "Obtient un token Azure B2C via ROPC (username/password).\nLe token est automatiquement sauvegardé dans la variable d'environnement accessToken.\n\nPrérequis : renseigner username et password dans l'environnement actif."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "const json = pm.response.json();",
+              "if (json.access_token) {",
+              "  pm.environment.set('accessToken', json.access_token);",
+              "  console.log('✅ Token sauvegardé dans accessToken (expire dans ' + json.expires_in + 's)');",
+              "} else {",
+              "  console.error('❌ Pas de access_token dans la réponse:', JSON.stringify(json));",
+              "}"
+            ]
+          }
+        }
+      ],
+      "response": []
+    },
+    {
+      "name": "Stocks",
+      "item": [
+        {
+          "name": "GET all stocks",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "GET stock details",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "POST create stock",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"label\": \"Mon stock\",\n  \"description\": \"Description du stock\",\n  \"category\": \"alimentation\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks"]
+            },
+            "description": "Catégories valides : alimentation | hygiene | artistique"
+          },
+          "response": []
+        },
+        {
+          "name": "PATCH update stock",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"label\": \"Nouveau label\",\n  \"description\": \"Nouvelle description\",\n  \"category\": \"hygiene\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "DELETE stock",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}"]
+            },
+            "description": "Supprime un stock et tous ses articles. Retourne 204."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Items",
+      "item": [
+        {
+          "name": "GET stock items",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}/items",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}", "items"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "POST add item to stock",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"label\": \"Nouvel article\",\n  \"quantity\": 10,\n  \"description\": \"Description de l'article\",\n  \"minimumStock\": 2\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}/items",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}", "items"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "PATCH update item quantity",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"quantity\": 25\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}/items/{{itemId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}", "items", "{{itemId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "PATCH update item — label + description + minimumStock",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"label\": \"Tomates bio\",\n  \"description\": \"Tomates bio du marché\",\n  \"minimumStock\": 5\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}/items/{{itemId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}", "items", "{{itemId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "PATCH update item — all fields",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"label\": \"Tomates bio\",\n  \"description\": \"Tomates bio du marché\",\n  \"minimumStock\": 5,\n  \"quantity\": 20\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}/items/{{itemId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}", "items", "{{itemId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "PATCH update item — empty body (no change)",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2/stocks/{{stockId}}/items/{{itemId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v2", "stocks", "{{stockId}}", "items", "{{itemId}}"]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- PATCH `/stocks/:stockId/items/:itemId` : summary, description et exemples mis à jour pour refléter `UpdateItemCommand` (#118)
- Ajout du schema `UpdateItemBody` (tous champs optionnels : `label`, `description`, `minimumStock`, `quantity`)
- Conservation de `UpdateItemQuantityBody` pour référence
- Collection Postman : 4 nouvelles requêtes de test ajoutées

Lié à #118