### PR TITLE
feat(stocks): add aggregated status to GET /stocks response — closes #142

### DIFF
--- a/src/domain/stock-management/common/entities/Stock.ts
+++ b/src/domain/stock-management/common/entities/Stock.ts
@@ -69,6 +69,16 @@ export class Stock {
     }).length;
   }
 
+  getAggregatedStatus(): 'optimal' | 'low' | 'critical' | 'out-of-stock' | 'overstocked' {
+    if (this.items.length === 0) return 'optimal';
+    const statuses = this.items.map(item => item.getStatus());
+    if (statuses.some(s => s === 'out-of-stock')) return 'out-of-stock';
+    if (statuses.some(s => s === 'critical')) return 'critical';
+    if (statuses.some(s => s === 'low')) return 'low';
+    if (statuses.every(s => s === 'overstocked')) return 'overstocked';
+    return 'optimal';
+  }
+
   addItem(params: {
     label: string;
     description?: string;

--- a/src/domain/stock-management/visualization/models/StockSummary.ts
+++ b/src/domain/stock-management/visualization/models/StockSummary.ts
@@ -17,6 +17,7 @@ export interface StockSummaryDto {
   totalItems: number;
   totalQuantity: number;
   criticalItemsCount: number;
+  status: 'optimal' | 'low' | 'critical' | 'out-of-stock' | 'overstocked';
 }
 
 export interface StockDetailDto extends StockSummaryDto {
@@ -32,6 +33,7 @@ export function toStockSummaryDto(stock: Stock): StockSummaryDto {
     totalItems: stock.getTotalItems(),
     totalQuantity: stock.getTotalQuantity(),
     criticalItemsCount: stock.getCriticalItemsCount(),
+    status: stock.getAggregatedStatus(),
   };
 }
 

--- a/tests/api/controllers/StockControllerVisualization.test.ts
+++ b/tests/api/controllers/StockControllerVisualization.test.ts
@@ -1,6 +1,10 @@
 import { StockControllerVisualization } from '@api/controllers/StockControllerVisualization';
 import { CustomError, sendError } from '@core/errors';
 import { StockVisualizationService } from '@domain/stock-management/visualization/services/StockVisualizationService';
+import {
+  StockSummaryDto,
+  StockDetailDto,
+} from '@domain/stock-management/visualization/models/StockSummary';
 import { UserService } from '@services/userService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
 import { ReadUserRepository } from '@services/readUserRepository';
@@ -53,7 +57,7 @@ describe('StockControllerVisualization', () => {
     describe('when the service call is successful', () => {
       it('should return 200 and the list of stocks', async () => {
         mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
-        const mockStocks = [
+        const mockStocks: StockSummaryDto[] = [
           {
             id: 1,
             label: 'Stock 1',
@@ -62,6 +66,7 @@ describe('StockControllerVisualization', () => {
             totalItems: 0,
             totalQuantity: 0,
             criticalItemsCount: 0,
+            status: 'optimal',
           },
         ];
         mockStockService.getAllStocks.mockResolvedValue(mockStocks);
@@ -90,7 +95,7 @@ describe('StockControllerVisualization', () => {
       it('should return 200 and the stock details', async () => {
         req = { params: { stockId: '1' } };
         mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
-        const mockStock = {
+        const mockStock: StockDetailDto = {
           id: 1,
           label: 'Stock 1',
           description: 'Description 1',
@@ -98,6 +103,7 @@ describe('StockControllerVisualization', () => {
           totalItems: 0,
           totalQuantity: 0,
           criticalItemsCount: 0,
+          status: 'optimal',
           items: [],
         };
         mockStockService.getStockDetails.mockResolvedValue(mockStock);

--- a/tests/domain/stock-management/common/entities/Stock.test.ts
+++ b/tests/domain/stock-management/common/entities/Stock.test.ts
@@ -285,4 +285,60 @@ describe('Stock', () => {
       });
     });
   });
+
+  describe('getAggregatedStatus()', () => {
+    describe('when stock has no items', () => {
+      it('should return optimal', () => {
+        const stock = new Stock(1, 'S', '', 'alimentation', []);
+        expect(stock.getAggregatedStatus()).toBe('optimal');
+      });
+    });
+
+    describe('when all items are optimal', () => {
+      it('should return optimal', () => {
+        const stock = new Stock(1, 'S', '', 'alimentation', [new StockItem(1, 'A', 10, '', 5, 1)]);
+        expect(stock.getAggregatedStatus()).toBe('optimal');
+      });
+    });
+
+    describe('when at least one item is low', () => {
+      it('should return low', () => {
+        const stock = new Stock(1, 'S', '', 'alimentation', [
+          new StockItem(1, 'A', 10, '', 5, 1),
+          new StockItem(2, 'B', 6, '', 5, 1),
+        ]);
+        expect(stock.getAggregatedStatus()).toBe('low');
+      });
+    });
+
+    describe('when at least one item is critical', () => {
+      it('should return critical', () => {
+        const stock = new Stock(1, 'S', '', 'alimentation', [
+          new StockItem(1, 'A', 10, '', 5, 1),
+          new StockItem(2, 'B', 1, '', 5, 1),
+        ]);
+        expect(stock.getAggregatedStatus()).toBe('critical');
+      });
+    });
+
+    describe('when at least one item is out-of-stock', () => {
+      it('should return out-of-stock', () => {
+        const stock = new Stock(1, 'S', '', 'alimentation', [
+          new StockItem(1, 'A', 10, '', 5, 1),
+          new StockItem(2, 'B', 0, '', 5, 1),
+        ]);
+        expect(stock.getAggregatedStatus()).toBe('out-of-stock');
+      });
+    });
+
+    describe('priority: out-of-stock > critical > low', () => {
+      it('should return out-of-stock when mix of statuses', () => {
+        const stock = new Stock(1, 'S', '', 'alimentation', [
+          new StockItem(1, 'A', 0, '', 5, 1),
+          new StockItem(2, 'B', 1, '', 5, 1),
+        ]);
+        expect(stock.getAggregatedStatus()).toBe('out-of-stock');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## 🔗 Issue liée

Closes #142

## 📋 Description

Ajout du champ `status` agrégé dans la réponse `GET /stocks`, calculé à partir des statuts de tous les items du stock.

## 🔧 Détails d'implémentation

**Couches impactées :**
- `src/domain/stock-management/common/entities/Stock.ts` — nouvelle méthode `getAggregatedStatus()` : priorité `out-of-stock` > `critical` > `low` > `optimal`
- `src/domain/stock-management/visualization/models/StockSummary.ts` — ajout `status` dans `StockSummaryDto` et `toStockSummaryDto()`
- `tests/` — mocks mis à jour + 7 nouveaux tests `getAggregatedStatus()`

## 🧪 Type de changement

- [x] ✨ Nouvelle fonctionnalité (feat)

## ✅ Checklist

- [x] 185 tests passent (+7)
- [x] TypeScript 0 erreurs
- [x] ESLint 0 warnings

Closes #142