### PR TITLE
fix(suggestions): compute predictions for all items before LLM cache — closes #141

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
   setupFiles: ['dotenv/config'],
-  testMatch: ['**/tests/domain/**/*.test.ts'],
+  testMatch: ['**/tests/domain/**/*.test.ts', '**/tests/api/controllers/**/*.test.ts'],
   testPathIgnorePatterns: [
     '/node_modules/',
     '/tests/integration/',

--- a/src/api/controllers/StockSuggestionsController.ts
+++ b/src/api/controllers/StockSuggestionsController.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { AuthenticatedRequest } from '@api/types/AuthenticatedRequest';
 import { AISuggestion, IAIService } from '@domain/ai/IAIService';
 import { IPredictionRepository } from '@domain/prediction/repositories/IPredictionRepository';
+import { StockPredictionService } from '@domain/prediction/services/StockPredictionService';
 import { IStockVisualizationRepository } from '@domain/stock-management/visualization/queries/IStockVisualizationRepository';
 import { UserService } from '@services/userService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
@@ -18,7 +19,8 @@ export class StockSuggestionsController {
     private readonly visualizationRepository: IStockVisualizationRepository,
     private readonly predictionRepository: IPredictionRepository,
     private readonly aiService: IAIService,
-    private readonly userService: UserService
+    private readonly userService: UserService,
+    private readonly predictionService: StockPredictionService
   ) {}
 
   private validateOID(OID: string, res: express.Response): boolean {
@@ -56,11 +58,21 @@ export class StockSuggestionsController {
       }
 
       const predictions = await Promise.all(
-        items.map(async item => ({
-          item,
-          prediction: await this.predictionRepository.getLatest(item.id),
-          cached: await this.predictionRepository.getCachedAISuggestions(item.id),
-        }))
+        items.map(async item => {
+          const existing = await this.predictionRepository.getLatest(item.id);
+          const prediction =
+            existing ??
+            (await this.predictionService.computeAndSave(
+              item.id,
+              item.quantity,
+              item.minimumStock ?? 1
+            ));
+          return {
+            item,
+            prediction,
+            cached: await this.predictionRepository.getCachedAISuggestions(item.id),
+          };
+        })
       );
 
       const now = Date.now();

--- a/src/api/routes/StockRoutesV2.ts
+++ b/src/api/routes/StockRoutesV2.ts
@@ -73,7 +73,8 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
     prismaRepository,
     predictionRepository,
     aiService,
-    userService
+    userService,
+    predictionService
   );
 
   const manipulationController = new StockControllerManipulation(

--- a/tests/api/controllers/StockControllerManipulation.test.ts
+++ b/tests/api/controllers/StockControllerManipulation.test.ts
@@ -164,7 +164,7 @@ describe('StockControllerManipulation', () => {
           },
         };
         const error = new Error('fail to add item');
-        mockUserService.convertOIDtoUserID = jest.fn().mockRejectedValue(error);
+        mockAddItemHandler.handle = jest.fn().mockRejectedValue(error);
 
         await controller.addItemToStock(req as AddItemToStockRequest, res);
 
@@ -209,7 +209,7 @@ describe('StockControllerManipulation', () => {
           },
         };
         const error = new Error('fail to update quantity');
-        mockUserService.convertOIDtoUserID = jest.fn().mockRejectedValue(error);
+        mockUpdateQuantityHandler.handle = jest.fn().mockRejectedValue(error);
 
         await controller.updateItemQuantity(req as UpdateItemQuantityRequest, res);
 

--- a/tests/api/controllers/StockControllerVisualization.test.ts
+++ b/tests/api/controllers/StockControllerVisualization.test.ts
@@ -44,7 +44,7 @@ describe('StockControllerVisualization', () => {
     ) as jest.Mocked<UserService>;
     controller = new StockControllerVisualization(mockStockService, mockUserService);
 
-    req = {};
+    req = { userID: 'test-oid' };
     res = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
@@ -93,7 +93,7 @@ describe('StockControllerVisualization', () => {
   describe('getStockDetails', () => {
     describe('when the service call is successful', () => {
       it('should return 200 and the stock details', async () => {
-        req = { params: { stockId: '1' } };
+        req = { userID: 'test-oid', params: { stockId: '1' } };
         mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
         const mockStock: StockDetailDto = {
           id: 1,
@@ -117,7 +117,7 @@ describe('StockControllerVisualization', () => {
 
     describe('when the service call fails', () => {
       it('should call sendError', async () => {
-        req = { params: { stockId: '1' } };
+        req = { userID: 'test-oid', params: { stockId: '1' } };
         const error = new Error('not found');
         mockUserService.convertOIDtoUserID = jest.fn().mockRejectedValue(error);
 
@@ -131,7 +131,7 @@ describe('StockControllerVisualization', () => {
   describe('getStockItems', () => {
     describe('when the service call is successful', () => {
       it('should return 200 and the items of the stock', async () => {
-        req = { params: { stockId: '1' } };
+        req = { userID: 'test-oid', params: { stockId: '1' } };
         mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
         const mockItems = [
           { id: 1, label: 'Item 1', description: 'desc', category: 'alimentation' },
@@ -147,7 +147,7 @@ describe('StockControllerVisualization', () => {
 
     describe('when the service call fails', () => {
       it('should call sendError', async () => {
-        req = { params: { stockId: '1' } };
+        req = { userID: 'test-oid', params: { stockId: '1' } };
         const error = new Error('fail items');
         mockUserService.convertOIDtoUserID = jest.fn().mockRejectedValue(error);
 

--- a/tests/api/controllers/StockSuggestionsController.test.ts
+++ b/tests/api/controllers/StockSuggestionsController.test.ts
@@ -1,0 +1,163 @@
+import { StockSuggestionsController } from '@api/controllers/StockSuggestionsController';
+import '@core/errors';
+import { IAIService } from '@domain/ai/IAIService';
+import { IPredictionRepository } from '@domain/prediction/repositories/IPredictionRepository';
+import { StockPredictionService } from '@domain/prediction/services/StockPredictionService';
+import { IStockVisualizationRepository } from '@domain/stock-management/visualization/queries/IStockVisualizationRepository';
+import { UserService } from '@services/userService';
+import { HTTP_CODE_OK } from '@utils/httpCodes';
+import { Request, Response } from 'express';
+
+jest.mock('@core/errors', () => ({ sendError: jest.fn() }));
+jest.mock('@utils/logger', () => ({
+  rootController: {
+    getChildCategory: () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }),
+  },
+}));
+jest.mock('@utils/cloudLogger', () => ({ rootException: jest.fn() }));
+
+const makeItem = (id: number) => ({
+  id,
+  label: `Item ${id}`,
+  quantity: 10,
+  minimumStock: 5,
+});
+
+const makePrediction = (itemId: number) => ({
+  id: itemId,
+  itemId,
+  daysUntilEmpty: 14,
+  avgDailyConsumption: 1,
+  trend: 'STABLE' as const,
+  recommendedRestock: 10,
+  simulatedFallback: false,
+  generatedAt: new Date(),
+});
+
+describe('StockSuggestionsController', () => {
+  let controller: StockSuggestionsController;
+  let req: Partial<Request>;
+  let res: jest.Mocked<Response>;
+  let mockVisualizationRepo: jest.Mocked<IStockVisualizationRepository>;
+  let mockPredictionRepo: jest.Mocked<IPredictionRepository>;
+  let mockAIService: jest.Mocked<IAIService>;
+  let mockUserService: jest.Mocked<UserService>;
+  let mockPredictionService: jest.Mocked<StockPredictionService>;
+
+  beforeEach(() => {
+    mockVisualizationRepo = {
+      getAllStocks: jest.fn(),
+      getStockDetails: jest.fn(),
+      getStockItems: jest.fn(),
+    } as unknown as jest.Mocked<IStockVisualizationRepository>;
+
+    mockPredictionRepo = {
+      getLatest: jest.fn(),
+      save: jest.fn(),
+      getCachedAISuggestions: jest.fn(),
+      saveAISuggestions: jest.fn(),
+    } as unknown as jest.Mocked<IPredictionRepository>;
+
+    mockAIService = {
+      generateSuggestions: jest.fn().mockResolvedValue([
+        {
+          itemId: 1,
+          type: 'RESTOCK',
+          priority: 'high',
+          title: 'T',
+          description: 'D',
+          source: 'llm',
+        },
+      ]),
+    };
+
+    mockUserService = {
+      convertOIDtoUserID: jest.fn().mockResolvedValue({ value: 42 }),
+    } as unknown as jest.Mocked<UserService>;
+
+    mockPredictionService = {
+      computeAndSave: jest.fn().mockResolvedValue(makePrediction(1)),
+    } as unknown as jest.Mocked<StockPredictionService>;
+
+    controller = new StockSuggestionsController(
+      mockVisualizationRepo,
+      mockPredictionRepo,
+      mockAIService,
+      mockUserService,
+      mockPredictionService
+    );
+
+    req = { userID: 'oid', params: { stockId: '1' } };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as jest.Mocked<Response>;
+  });
+
+  describe('getStockSuggestions', () => {
+    describe('when all items have cached suggestions', () => {
+      it('should return cached suggestions without calling AI', async () => {
+        const item = makeItem(1);
+        const cachedSuggestion = {
+          data: [
+            {
+              itemId: 1,
+              type: 'RESTOCK',
+              priority: 'high',
+              title: 'T',
+              description: 'D',
+              source: 'llm',
+            },
+          ],
+          generatedAt: new Date(),
+        };
+
+        mockVisualizationRepo.getStockItems.mockResolvedValue([item] as any);
+        mockPredictionRepo.getLatest.mockResolvedValue(makePrediction(1));
+        mockPredictionRepo.getCachedAISuggestions.mockResolvedValue(cachedSuggestion);
+
+        await controller.getStockSuggestions(req as any, res);
+
+        expect(mockAIService.generateSuggestions).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+      });
+    });
+
+    describe('when an item has no existing prediction', () => {
+      it('should call computeAndSave for that item', async () => {
+        const item = makeItem(1);
+
+        mockVisualizationRepo.getStockItems.mockResolvedValue([item] as any);
+        mockPredictionRepo.getLatest.mockResolvedValue(null);
+        mockPredictionRepo.getCachedAISuggestions.mockResolvedValue(null);
+        mockPredictionRepo.saveAISuggestions.mockResolvedValue();
+
+        await controller.getStockSuggestions(req as any, res);
+
+        expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(1, 10, 5);
+        expect(mockAIService.generateSuggestions).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+      });
+    });
+
+    describe('when stock has no items', () => {
+      it('should return 404', async () => {
+        mockVisualizationRepo.getStockItems.mockResolvedValue([]);
+
+        await controller.getStockSuggestions(req as any, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+      });
+    });
+
+    describe('when stockId is invalid', () => {
+      it('should return 400', async () => {
+        req = { userID: 'oid', params: { stockId: 'abc' } };
+
+        await controller.getStockSuggestions(req as any, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔗 Issue liée

Closes #141

## 📋 Description

Le cache des suggestions LLM ne se sauvegardait jamais car `saveAISuggestions` retourne silencieusement si aucune `stockPrediction` n'existe pour l'item. Seuls les items critiques avaient une prédiction (appelée par le frontend). Les items OK (Café Arabica, Thé Vert) n'en avaient pas → cache jamais écrit → appel OpenRouter à chaque fois (~26s).

## 🔧 Détails d'implémentation

**Couches impactées :**
- `src/api/controllers/StockSuggestionsController.ts` — injection de `StockPredictionService` ; si `getLatest()` retourne `null`, appel de `computeAndSave()` avant de construire le contexte LLM
- `src/api/routes/StockRoutesV2.ts` — passage de `predictionService` au constructeur
- `jest.config.js` — ajout de `tests/api/controllers/` au `testMatch`
- `tests/api/controllers/StockSuggestionsController.test.ts` — nouveau fichier (4 tests)
- `tests/api/controllers/StockControllerVisualization.test.ts` — correction `userID` manquant dans les mocks
- `tests/api/controllers/StockControllerManipulation.test.ts` — correction mocks d'erreur (handler.handle au lieu de convertOIDtoUserID)

## 🧪 Type de changement

- [x] 🐛 Correction de bug (fix)

## ✅ Checklist

- [x] 201 tests passent (+16)
- [x] TypeScript 0 erreurs
- [x] ESLint 0 warnings