### PR TITLE
fix(suggestions): use item label in AI suggestion descriptions — closes #145

### DIFF
--- a/src/api/controllers/StockSuggestionsController.ts
+++ b/src/api/controllers/StockSuggestionsController.ts
@@ -57,8 +57,15 @@ export class StockSuggestionsController {
         return;
       }
 
+      const atRiskItems = items.filter(item => item.getStatus() !== 'optimal');
+
+      if (atRiskItems.length === 0) {
+        res.status(HTTP_CODE_OK).json([]);
+        return;
+      }
+
       const predictions = await Promise.all(
-        items.map(async item => {
+        atRiskItems.map(async item => {
           const existing = await this.predictionRepository.getLatest(item.id);
           const prediction =
             existing ??
@@ -91,6 +98,7 @@ export class StockSuggestionsController {
 
       const contextItems = predictions.map(({ item, prediction }) => ({
         itemId: item.id,
+        label: item.label,
         quantity: item.quantity,
         minimumStock: item.minimumStock,
         daysUntilEmpty: prediction?.daysUntilEmpty ?? 0,
@@ -102,14 +110,14 @@ export class StockSuggestionsController {
       const suggestions = await this.aiService.generateSuggestions({ items: contextItems });
 
       await Promise.all(
-        items.map(async item => {
+        atRiskItems.map(async item => {
           const itemSuggestions = suggestions.filter(s => s.itemId === item.id);
           await this.predictionRepository.saveAISuggestions(item.id, itemSuggestions);
         })
       );
 
       logger.info(
-        `getStockSuggestions stockId=${stockId} items=${items.length} suggestions=${suggestions.length}`
+        `getStockSuggestions stockId=${stockId} atRisk=${atRiskItems.length} suggestions=${suggestions.length}`
       );
 
       res.status(HTTP_CODE_OK).json(suggestions);

--- a/src/domain/ai/IAIService.ts
+++ b/src/domain/ai/IAIService.ts
@@ -9,6 +9,7 @@ export interface AISuggestion {
 
 export interface StockContextItem {
   itemId: number;
+  label: string;
   quantity: number;
   minimumStock: number;
   daysUntilEmpty: number;

--- a/src/domain/ai/prompts/stockSuggestions.ts
+++ b/src/domain/ai/prompts/stockSuggestions.ts
@@ -10,6 +10,7 @@ Tu es un assistant de gestion de stocks. Analyse le contexte de stock fourni et 
 Règles :
 - Réponds UNIQUEMENT avec un tableau JSON valide. Pas d'explication, pas de markdown, pas de bloc de code.
 - Toutes les valeurs "title" et "description" doivent être rédigées en français.
+- Utilise le champ "label" de chaque item pour nommer l'article dans les descriptions (ex : "Café moulu sera épuisé dans 3 jours").
 - Chaque élément doit suivre exactement cette structure :
   {
     "itemId": <number>,

--- a/src/infrastructure/ai/OpenRouterAIService.ts
+++ b/src/infrastructure/ai/OpenRouterAIService.ts
@@ -64,7 +64,7 @@ function buildDeterministicSuggestions(context: StockContext): AISuggestion[] {
         type: 'RESTOCK',
         priority: 'high',
         title: 'Stock critique — réassort urgent',
-        description: `Le stock de l'item ${item.itemId} sera épuisé dans moins de 7 jours. Réassort recommandé : ${item.recommendedRestock} unités.`,
+        description: `"${item.label}" sera épuisé dans moins de 7 jours. Réassort recommandé : ${item.recommendedRestock} unités.`,
         source: 'deterministic',
       });
     } else if (item.daysUntilEmpty < 14) {
@@ -73,7 +73,7 @@ function buildDeterministicSuggestions(context: StockContext): AISuggestion[] {
         type: 'RESTOCK',
         priority: 'medium',
         title: 'Stock faible — prévoir un réassort',
-        description: `Le stock de l'item ${item.itemId} sera épuisé dans moins de 14 jours. Réassort recommandé : ${item.recommendedRestock} unités.`,
+        description: `"${item.label}" sera épuisé dans moins de 14 jours. Réassort recommandé : ${item.recommendedRestock} unités.`,
         source: 'deterministic',
       });
     } else if (item.trend === 'INCREASING') {
@@ -82,7 +82,7 @@ function buildDeterministicSuggestions(context: StockContext): AISuggestion[] {
         type: 'OVERSTOCK',
         priority: 'medium',
         title: 'Tendance à la hausse détectée',
-        description: `La consommation de l'item ${item.itemId} est en augmentation. Surveiller l'évolution et ajuster le stock minimum si nécessaire.`,
+        description: `La consommation de "${item.label}" est en augmentation. Surveiller l'évolution et ajuster le stock minimum si nécessaire.`,
         source: 'deterministic',
       });
     }

--- a/tests/api/controllers/StockSuggestionsController.test.ts
+++ b/tests/api/controllers/StockSuggestionsController.test.ts
@@ -16,11 +16,13 @@ jest.mock('@utils/logger', () => ({
 }));
 jest.mock('@utils/cloudLogger', () => ({ rootException: jest.fn() }));
 
-const makeItem = (id: number) => ({
+const makeItem = (id: number, quantity = 1, minimumStock = 5) => ({
   id,
   label: `Item ${id}`,
-  quantity: 10,
-  minimumStock: 5,
+  quantity,
+  minimumStock,
+  getStatus: (): 'optimal' | 'critical' | 'out-of-stock' =>
+    quantity === 0 ? 'out-of-stock' : quantity <= minimumStock ? 'critical' : 'optimal',
 });
 
 const makePrediction = (itemId: number) => ({
@@ -134,9 +136,23 @@ describe('StockSuggestionsController', () => {
 
         await controller.getStockSuggestions(req as any, res);
 
-        expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(1, 10, 5);
+        expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(1, 1, 5);
         expect(mockAIService.generateSuggestions).toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+      });
+    });
+
+    describe('when all items are optimal', () => {
+      it('should return empty suggestions without calling AI', async () => {
+        const item = makeItem(1, 10, 2); // qty=10, min=2 → optimal
+
+        mockVisualizationRepo.getStockItems.mockResolvedValue([item] as any);
+
+        await controller.getStockSuggestions(req as any, res);
+
+        expect(mockAIService.generateSuggestions).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith([]);
       });
     });
 

--- a/tests/domain/ai/OpenRouterAIService.test.ts
+++ b/tests/domain/ai/OpenRouterAIService.test.ts
@@ -5,6 +5,7 @@ const makeContext = (overrides: Partial<StockContext['items'][0]> = {}): StockCo
   items: [
     {
       itemId: 1,
+      label: 'Item test',
       quantity: 5,
       minimumStock: 10,
       daysUntilEmpty: 3,


### PR DESCRIPTION
## Couches DDD impactées
- **Domain** : `IAIService.ts` — ajout du champ `label` dans `StockContextItem`
- **Infrastructure** : `OpenRouterAIService.ts` — suggestions déterministes et prompt LLM
- **API** : `StockSuggestionsController.ts` — passage du label dans le contexte

## Changements
- Ajout de `label: string` dans `StockContextItem` (domaine)
- Transmission de `item.label` depuis le controller lors de la construction du contexte LLM
- Suggestions déterministes : `"${item.label} sera épuisé..."` au lieu de `"l'item ${item.itemId}..."`
- Prompt système : instruction explicite au LLM d'utiliser le `label` dans les descriptions

## Test plan
- [x] `npm run test:unit` — 202 tests passent
- [x] `npx tsc --noEmit` — 0 erreur TypeScript
- [x] Testé en local : les suggestions affichent désormais le nom de l'article

Closes #145