### PR TITLE
test(e2e): add status field assertions and status lifecycle scenario — closes #43

### DIFF
--- a/tests/e2e/stock-management/stock-crud-v2.e2e.test.ts
+++ b/tests/e2e/stock-management/stock-crud-v2.e2e.test.ts
@@ -191,8 +191,14 @@ describe('Stock API V2', () => {
         });
 
         expect(response.status()).toBe(200);
-        const body = await response.json();
-        const updatedItem = body.items?.find((i: any) => i.id === itemId);
+
+        // PATCH returns domain entity (no computed status) — verify via GET
+        const getResponse = await request.get(`${apiV2}/stocks/${stockId}/items`, {
+          headers: { Authorization: authToken },
+        });
+        expect(getResponse.status()).toBe(200);
+        const items = await getResponse.json();
+        const updatedItem = items.find((i: any) => i.id === itemId);
         if (updatedItem) {
           expect(updatedItem.quantity).toBe(99);
           // quantity:99 > minimumStock*3 (15) → overstocked
@@ -212,7 +218,11 @@ describe('Stock API V2', () => {
     it.beforeAll(async ({ request }) => {
       const stockRes = await request.post(`${apiV2}/stocks`, {
         headers: { Authorization: authToken },
-        data: { label: 'E2E Status Stock', category: 'alimentation' },
+        data: {
+          label: 'E2E Status Stock',
+          description: 'Stock for status lifecycle tests',
+          category: 'alimentation',
+        },
       });
       statusStockId = (await stockRes.json()).id;
 
@@ -236,8 +246,12 @@ describe('Stock API V2', () => {
         data: { quantity },
       });
       expect(res.status()).toBe(200);
-      const body = await res.json();
-      return body.items?.find((i: any) => i.id === statusItemId);
+      // PATCH returns domain entity (no computed status) — verify via GET
+      const getRes = await request.get(`${apiV2}/stocks/${statusStockId}/items`, {
+        headers: { Authorization: authToken },
+      });
+      const items = await getRes.json();
+      return items.find((i: any) => i.id === statusItemId);
     };
 
     it('quantity:3 ≤ min:10 → critical', async ({ request }) => {


### PR DESCRIPTION
## Résumé

Complète la couverture E2E sur le champ métier `status` des items, qui était absent des assertions existantes (seuls les codes HTTP étaient vérifiés).

## Changements

### Assertions ajoutées dans les tests existants
- `GET /stocks/:id/items` : vérification du shape complet du DTO (`minimumStock`, `status`)
- `PATCH /stocks/:id/items/:itemId` : vérification du `status` après mise à jour de quantité

### Nouveau bloc — Cycle de vie du statut
Scénario dédié avec `minimumStock: 10`, couvrant les 5 valeurs possibles :

| quantity | calcul | status attendu |
|---|---|---|
| 3 | ≤ min (10) | `critical` |
| 14 | ≤ min × 1.5 (15) | `low` |
| 20 | dans (15, 30] | `optimal` |
| 31 | > min × 3 (30) | `overstocked` |
| 0 | quantity = 0 | `out-of-stock` |

## Couches impactées

- `tests/e2e/stock-management/stock-crud-v2.e2e.test.ts` uniquement

## Test plan

- [x] TypeScript : 0 erreur
- [x] Logique status vérifiée contre `StockItem.getStatus()` (`src/domain/stock-management/common/entities/StockItem.ts`)
- [ ] Tests E2E à valider en CI contre l'environnement staging

Closes #43