### PR TITLE
chore(ci): add npm outdated check to CI pipeline

### DIFF
--- a/.github/workflows/main_stockhub-back.yml
+++ b/.github/workflows/main_stockhub-back.yml
@@ -33,6 +33,9 @@ jobs:
       - run: npm run lint --if-present
       - run: npm run test:unit
 
+      - name: Check outdated dependencies (informational)
+        run: npm outdated || true
+
   # E2E Tests - s'exécute sur PR vers main et workflow_dispatch
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -38,3 +38,6 @@ jobs:
         run: |
           echo "✅ No HIGH or CRITICAL vulnerabilities detected"
           npm audit --audit-level=moderate || echo "⚠️ Some MODERATE/LOW vulnerabilities found (non-blocking)"
+
+      - name: Check outdated dependencies (informational)
+        run: npm outdated || true


### PR DESCRIPTION
## Contexte

Constat de l'absence d'un check automatique des dépendances obsolètes. Le pipeline contenait déjà `npm audit` (sécurité) mais pas `npm outdated` (versions en retard).

## Changements

- **`.github/workflows/main_stockhub-back.yml`** : step `npm outdated || true` ajouté en fin du job `continuous-integration` — visible à chaque push/PR, non-bloquant
- **`.github/workflows/security-audit.yml`** : même step ajouté en fin du job hebdomadaire — regroupe sécurité + obsolescence dans le même rapport

## Comportement

`npm outdated` retourne un code de sortie non-zéro si des dépendances sont en retard. Le `|| true` assure que le build ne casse pas — le résultat est purement informatif et visible dans les logs CI.

## Couches DDD impactées

Infrastructure CI uniquement — aucun changement de code.

## Test plan

- [x] Workflow valide YAML (Prettier OK)
- [x] Step non-bloquant (`|| true`)
- [x] Visible dans les logs CI à chaque run

Closes #163