### PR TITLE
fix(visualization): allow collaborators to access shared stock details — closes #154

### DIFF
--- a/src/infrastructure/stock-management/visualization/repositories/PrismaStockVisualizationRepository.ts
+++ b/src/infrastructure/stock-management/visualization/repositories/PrismaStockVisualizationRepository.ts
@@ -73,7 +73,10 @@ export class PrismaStockVisualizationRepository implements IStockVisualizationRe
 
   async getStockDetails(stockId: number, userId: number): Promise<Stock | null> {
     const stock = await this.prisma.stock.findFirst({
-      where: { id: stockId, userId: userId },
+      where: {
+        id: stockId,
+        OR: [{ userId }, { collaborators: { some: { userId } } }],
+      },
       include: { items: true },
     });
     if (!stock) {
@@ -103,7 +106,10 @@ export class PrismaStockVisualizationRepository implements IStockVisualizationRe
 
     try {
       const stock = await this.prisma.stock.findFirst({
-        where: { id: stockId, userId: userId },
+        where: {
+          id: stockId,
+          OR: [{ userId }, { collaborators: { some: { userId } } }],
+        },
       });
       if (!stock) {
         throw new Error('Stock not found or access denied');


### PR DESCRIPTION
## Changements

- `getStockDetails` : condition élargie à `owner OR collaborator` (était owner uniquement)
- `getStockItems` : idem

## Cause

`findFirst({ where: { id, userId } })` rejetait les collaborateurs → page détail retournait \"Stock introuvable\" pour un stock partagé.

## Test plan

- [x] Collaborateur accède à la page détail d'un stock partagé → s'affiche correctement
- [x] Propriétaire accède à ses propres stocks → comportement inchangé
- [x] Utilisateur sans accès → toujours rejeté

Closes #154