### PR TITLE
refactor(arch): align src/ with DDD/CQRS layers — closes #194

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,22 @@ gh issue create --label "back,bug" ...
 gh issue edit <numero> --repo SandrineCipolla/stockhub_back --add-label "back,bug"
 ```
 
+### Association au GitHub Project (obligatoire)
+
+Toute issue doit être associée au **GitHub Project** du projet :
+
+```bash
+# Lors de la création
+gh issue create --label "back,bug" --project "StockHub V2"
+
+# Après coup si oublié
+gh issue edit <numero> --repo SandrineCipolla/stockhub_back --add-project "StockHub V2"
+```
+
+**URL du project** : https://github.com/users/SandrineCipolla/projects/3
+
+Sans cette association, l'issue n'apparaît pas dans le board de suivi et ne peut pas être déplacée entre les colonnes (Backlog → In Progress → Done).
+
 ### ⚠️ AVANT de créer une issue GitHub
 
 **Format User Story** :

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -1,0 +1,482 @@
+# Audit Architecture DDD/CQRS — stockhub_back
+
+**Date :** 10 avril 2026
+**Version auditée :** v2.1.1 — branche `main`
+**Auditeur :** Claude Code (à partir du code réel, sans supposition)
+
+---
+
+## 1. Cartographie complète de `src/`
+
+```
+src/
+├── index.ts                                  # Point d'entrée Node.js
+├── initializeApp.ts                          # Bootstrap Express (CORS, Passport, routes, Swagger)
+├── authConfig.ts                             # Config Azure AD B2C (clientID, authority, audience)
+│
+├── authentication/
+│   ├── authBearerStrategy.ts                 # Stratégie Passport Bearer (Azure B2C)
+│   └── authenticateMiddleware.ts             # Middleware d'authentification (extrait email du token)
+│
+├── authorization/
+│   ├── authorizeMiddleware.ts                # Middleware d'autorisation resource-based (OWNER/EDITOR/VIEWER)
+│   ├── constants/permissions.ts              # Constantes PERMISSIONS, HTTP_STATUS, messages d'erreur
+│   └── repositories/AuthorizationRepository.ts # Accès Prisma pour vérifier ownership/rôle collaborateur
+│
+├── config/
+│   ├── authenticationConfig.ts               # Lecture des variables d'env Azure B2C
+│   ├── httpPortConfiguration.ts              # Résolution du port HTTP
+│   ├── models.ts                             # Types partagés de configuration
+│   ├── openapi.config.ts                     # Chargement du fichier openapi.yaml + spec Swagger
+│   └── runtimeMode.ts                        # Détection mode dev/prod
+│
+├── serverSetup/
+│   └── setupHttpServer.ts                    # Démarrage du serveur HTTP (listen)
+│
+├── Utils/
+│   ├── cloudLogger.ts                        # Logger Azure Application Insights (rootException)
+│   ├── express.d.ts                          # Augmentation du type Express.Request (userID, authInfo)
+│   ├── httpCodes.ts                          # Constantes HTTP_CODE_OK, HTTP_CODE_CREATED
+│   └── logger.ts                             # Logger structuré (rootMain, rootController, rootDatabase, rootSecurity...)
+│
+├── services/                                 # ⚠️ Couche orpheline — voir §2.4
+│   ├── readUserRepository.ts                 # Lecture utilisateur via Prisma (OID → ID)
+│   ├── userService.ts                        # Conversion OID Azure → ID interne + création automatique
+│   └── writeUserRepository.ts               # Création utilisateur via Prisma (upsert)
+│
+├── api/
+│   ├── errors.ts                             # Types CustomError + fonction sendError
+│   ├── controllers/
+│   │   ├── StockCollaboratorController.ts    # CRUD collaborateurs (add/update/remove/list)
+│   │   ├── StockContributionController.ts    # Workflow contributions VIEWER_CONTRIBUTOR
+│   │   ├── StockControllerManipulation.ts    # Commandes stocks et items (create/update/delete)
+│   │   ├── StockControllerVisualization.ts   # Lectures stocks (getAllStocks, getStockDetails, getStockItems)
+│   │   ├── StockPredictionController.ts      # Endpoints historique + prédictions
+│   │   └── StockSuggestionsController.ts     # Endpoint suggestions IA (LLM + déterministe)
+│   ├── dto/
+│   │   ├── StockDTO.ts                       # Types DTO (StockSummaryDto, StockDetailDto, StockItemDto…)
+│   │   └── mappers/StockMapper.ts            # Mappers entités → DTO pour la sérialisation API
+│   ├── routes/
+│   │   ├── StockRoutesV2.ts                  # Factory DI : instancie toute la chaîne et déclare les routes
+│   │   └── constants/routePaths.ts           # Constantes des chemins de routes (STOCK_ROUTES)
+│   └── types/
+│       ├── AuthenticatedRequest.ts           # Type Express.Request enrichi avec userID
+│       └── StockRequestTypes.ts              # Types des body/params pour chaque route
+│
+├── domain/
+│   ├── ai/
+│   │   ├── IAIService.ts                     # Interface domaine (generateSuggestions)
+│   │   └── prompts/stockSuggestions.ts       # Templates de prompts LLM
+│   │
+│   ├── authorization/
+│   │   ├── collaboration/
+│   │   │   ├── command-handlers/
+│   │   │   │   ├── AddCollaboratorCommandHandler.ts
+│   │   │   │   ├── CollaboratorPermissions.ts
+│   │   │   │   ├── RemoveCollaboratorCommandHandler.ts
+│   │   │   │   └── UpdateCollaboratorRoleCommandHandler.ts
+│   │   │   ├── commands/
+│   │   │   │   ├── AddCollaboratorCommand.ts
+│   │   │   │   ├── RemoveCollaboratorCommand.ts
+│   │   │   │   └── UpdateCollaboratorRoleCommand.ts
+│   │   │   └── repositories/ICollaboratorRepository.ts
+│   │   └── common/
+│   │       ├── entities/Family.ts            # Aggregate Family avec règles métier (lastAdmin, unicité)
+│   │       ├── errors/FamilyErrors.ts        # Erreurs domaine spécifiques (FamilyNameEmptyError…)
+│   │       └── value-objects/
+│   │           ├── FamilyRole.ts
+│   │           ├── FamilyRoleEnum.ts
+│   │           ├── StockRole.ts
+│   │           └── StockRoleEnum.ts
+│   │
+│   ├── prediction/
+│   │   ├── repositories/
+│   │   │   ├── IItemHistoryRepository.ts     # Interface historique des variations de quantité
+│   │   │   └── IPredictionRepository.ts      # Interface persistance des prédictions calculées
+│   │   └── services/StockPredictionService.ts # Service domaine : calcul déterministe (avg, trend, daysUntilEmpty)
+│   │
+│   └── stock-management/
+│       ├── common/
+│       │   ├── entities/
+│       │   │   ├── ItemContribution.ts       # Entité contribution (VIEWER_CONTRIBUTOR workflow)
+│       │   │   ├── Stock.ts                  # Agrégat principal (addItem, removeItem, updateItemQuantity…)
+│       │   │   └── StockItem.ts              # Entité item (getStatus, isLowStock, isOutOfStock)
+│       │   ├── enums/StockCategory.ts
+│       │   └── value-objects/
+│       │       ├── ContributionStatus.ts
+│       │       ├── Quantity.ts               # VO quantité (isZero, isLessOrEqualToMinimum)
+│       │       ├── StockDescription.ts
+│       │       └── StockLabel.ts             # VO label (validation min 3 / max 50 chars)
+│       ├── manipulation/
+│       │   ├── commands/                     # 9 Command objects (DTOs intention)
+│       │   ├── repositories/
+│       │   │   ├── IContributionRepository.ts
+│       │   │   └── IStockCommandRepository.ts
+│       │   └── use-cases/                    # 9 CommandHandlers (logique applicative écriture)
+│       └── visualization/
+│           ├── models/StockSummary.ts        # DTOs lecture (StockSummaryDto, StockDetailDto)
+│           ├── queries/IStockVisualizationRepository.ts
+│           └── services/StockVisualizationService.ts
+│
+└── infrastructure/
+    ├── ai/
+    │   └── OpenRouterAIService.ts            # Implémentation HTTP de IAIService (OpenRouter)
+    ├── authorization/
+    │   └── repositories/PrismaCollaboratorRepository.ts
+    ├── prediction/
+    │   └── repositories/
+    │       ├── PrismaItemHistoryRepository.ts
+    │       └── PrismaStockPredictionRepository.ts
+    └── stock-management/
+        ├── manipulation/
+        │   ├── repositories/
+        │   │   ├── PrismaContributionRepository.ts
+        │   │   └── PrismaStockCommandRepository.ts
+        │   └── types/prisma.ts               # Types intermédiaires Prisma → domaine
+        └── visualization/
+            └── repositories/PrismaStockVisualizationRepository.ts
+```
+
+**Total : 83 fichiers TypeScript dans `src/`**
+
+---
+
+## 2. Analyse par couche
+
+### 2.1 Domain — ✅ conforme (avec écarts mineurs justifiables)
+
+#### Sous-domaine `stock-management`
+
+| Composant DDD         | Présent        | Fichiers                                                                                                                                        |
+| --------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Aggregate root        | ✅             | `Stock` (addItem, removeItem, updateItemQuantity, invariants)                                                                                   |
+| Entity                | ✅             | `StockItem`, `ItemContribution`                                                                                                                 |
+| Value Objects         | ✅             | `Quantity`, `StockLabel`, `StockDescription`, `ContributionStatus`                                                                              |
+| Interfaces repository | ✅             | `IStockCommandRepository`, `IStockVisualizationRepository`, `IContributionRepository`                                                           |
+| Commands (intentions) | ✅             | 9 commands (CreateStock, AddItem, UpdateItem, UpdateItemQuantity, UpdateStock, DeleteStock, DeleteItem, CreateContribution, ReviewContribution) |
+| Command Handlers      | ✅             | 9 handlers dans `use-cases/`                                                                                                                    |
+| Domain Service        | ✅ (implicite) | Logique dans `Stock.create()`, `Stock.addItem()`                                                                                                |
+| Domain Events         | ❌ absent      | Pas de publication d'événements (ex: `ItemAdded`, `StockDeleted`)                                                                               |
+| Enum propre           | ✅             | `StockCategory`                                                                                                                                 |
+
+**Verdict :** Conforme au DDD pragmatique. Les règles métier sont dans les entités (`Stock.addItem` vérifie les doublons, la quantité négative ; `StockItem.getStatus` calcule le statut). L'absence de Domain Events est un écart assumé — défendable car le projet n'a pas encore de besoins d'audit trail ou d'event sourcing.
+
+**Observation sur `Stock` :** L'agrégat accepte `string | StockLabel` pour `label` et `description`. C'est un pragmatisme pour la reconstruction depuis la DB (évite de reconstruire les VOs à chaque lecture Prisma), mais cela affaiblit la protection de l'invariant à l'intérieur même de l'agrégat.
+
+#### Sous-domaine `authorization`
+
+| Composant DDD        | Présent | Fichiers                                                                       |
+| -------------------- | ------- | ------------------------------------------------------------------------------ |
+| Aggregate            | ✅      | `Family` (addMember, removeMember, updateMemberRole, protection dernier admin) |
+| Value Objects        | ✅      | `FamilyRole`, `StockRole` (encapsulent les enums + permissions)                |
+| Errors domaine       | ✅      | `FamilyErrors.ts` (FamilyNameEmptyError, LastAdminError…)                      |
+| Commands             | ✅      | AddCollaborator, UpdateCollaboratorRole, RemoveCollaborator                    |
+| Command Handlers     | ✅      | Les 3 handlers correspondants                                                  |
+| Interface repository | ✅      | `ICollaboratorRepository`                                                      |
+
+**Verdict :** Conforme. `Family` est un vrai aggregate root avec invariants (protection du dernier admin, unicité des membres). Le système de rôles `StockRole.hasRequiredPermission()` encapsule bien la logique de permissions.
+
+#### Sous-domaine `prediction`
+
+| Composant DDD         | Présent   | Fichiers                                                                                    |
+| --------------------- | --------- | ------------------------------------------------------------------------------------------- |
+| Domain Service        | ✅        | `StockPredictionService` (avgDailyConsumption, detectTrend, daysUntilEmpty, computeAndSave) |
+| Interfaces repository | ✅        | `IItemHistoryRepository`, `IPredictionRepository`                                           |
+| Entities / VOs        | ❌ absent | Les données de prédiction sont des objets plain (pas d'entité `Prediction`)                 |
+
+**Verdict :** DDD pragmatique. Le service de prédiction est pur (pas de dépendance infrastructure), stateless, entièrement testable via mocks des interfaces.
+
+#### Sous-domaine `ai`
+
+| Composant DDD     | Présent    | Fichiers                                                                    |
+| ----------------- | ---------- | --------------------------------------------------------------------------- |
+| Interface domaine | ✅         | `IAIService` (generateSuggestions)                                          |
+| Domain Service    | ❌ absent  | Pas de service domaine — `IAIService` est une interface pure                |
+| Prompts           | ⚠️ présent | `prompts/stockSuggestions.ts` — contenu de prompt (strings) dans le domaine |
+
+**Verdict :** Cohérent. L'interface `IAIService` est correctement placée dans le domaine, l'implémentation HTTP dans `infrastructure/ai/`. Les prompts dans `domain/ai/prompts/` sont défendables comme "connaissance métier sur comment interroger l'IA".
+
+---
+
+### 2.2 API (Présentation) — ✅ conforme
+
+#### Controllers
+
+Tous les controllers respectent le principe de couche présentation :
+
+- **Aucune logique métier** dans les controllers — ils reçoivent la requête, construisent une Command, appellent le handler, renvoient la réponse HTTP.
+- `StockControllerManipulation` : `getValidatedOID()` est la seule logique interne, et elle ne concerne que la validation d'authentification (extraction OID du token), pas la logique métier.
+- `StockVisualizationService` est appelé directement depuis `StockControllerVisualization` (côté Query, pas de Command).
+
+#### DTOs et Mappers
+
+- `StockDTO.ts` : DTOs de lecture (StockSummaryDto, StockDetailDto, StockItemDto) — bien séparés des entités domaine.
+- `StockMapper.ts` : Transformations entités → DTOs, correctement isolés dans l'API.
+
+#### Routes
+
+`StockRoutesV2.ts` joue le rôle de **composition root** (DI factory) : toutes les instanciations y sont centralisées. C'est le seul endroit où `new PrismaClient()` peut apparaître. Ce pattern (factory function `configureStockRoutesV2`) permet l'injection de `PrismaClient` pour les tests.
+
+**Observation :** La route `PATCH /stocks/:stockId/items/:itemId` appelle `manipulationController.updateItem()` mais la constante dans `routePaths.ts` s'appelle `UPDATE_ITEM_QUANTITY`. Cohérence du nommage à aligner.
+
+---
+
+### 2.3 Infrastructure — ✅ conforme
+
+Tous les repositories Prisma implémentent les interfaces définies dans le domaine :
+
+| Interface domaine               | Implémentation infrastructure        |
+| ------------------------------- | ------------------------------------ |
+| `IStockCommandRepository`       | `PrismaStockCommandRepository`       |
+| `IStockVisualizationRepository` | `PrismaStockVisualizationRepository` |
+| `IContributionRepository`       | `PrismaContributionRepository`       |
+| `ICollaboratorRepository`       | `PrismaCollaboratorRepository`       |
+| `IItemHistoryRepository`        | `PrismaItemHistoryRepository`        |
+| `IPredictionRepository`         | `PrismaStockPredictionRepository`    |
+| `IAIService`                    | `OpenRouterAIService`                |
+
+La règle de dépendance est respectée : l'infrastructure connaît le domaine (pour implémenter les interfaces), mais le domaine ne connaît pas l'infrastructure.
+
+**Pattern DI :** `prismaClient ?? new PrismaClient()` — systématiquement appliqué dans tous les repositories, ce qui permet l'injection d'un client de test sans container IoC.
+
+---
+
+### 2.4 Services (`src/services/`) — ⚠️ couche mal positionnée, mais contenu justifiable
+
+#### Contenu réel
+
+| Fichier                  | Ce qu'il fait vraiment                                                             | Couche DDD correcte    |
+| ------------------------ | ---------------------------------------------------------------------------------- | ---------------------- |
+| `readUserRepository.ts`  | Accès Prisma — `findUnique` sur `user` par email/OID                               | Infrastructure         |
+| `writeUserRepository.ts` | Accès Prisma — `upsert` sur `user`                                                 | Infrastructure         |
+| `userService.ts`         | Orchestration : convertit un OID Azure en ID interne, crée l'utilisateur si absent | Application (use case) |
+
+#### Verdict
+
+`src/services/` est une **couche applicative orpheline** — elle n'est ni domaine (contient du code Prisma), ni infrastructure (contient de la logique d'orchestration), ni api (n'expose pas de routes).
+
+**Raison historique :** Ce dossier est un héritage de la V1 (code pré-DDD). Il a survécu à la migration car `UserService` est injecté dans plusieurs controllers et handlers. La migration Prisma de `UserService` a été faite (issue #192) mais le placement n'a pas été corrigé.
+
+**Recommandation DDD :**
+
+- `readUserRepository.ts` → `src/infrastructure/user/repositories/PrismaReadUserRepository.ts`
+- `writeUserRepository.ts` → `src/infrastructure/user/repositories/PrismaWriteUserRepository.ts`
+- `userService.ts` → `src/domain/user/services/UserService.ts` (ou couche application si isolée)
+
+**Formulation orale pour le jury :** _"Le dossier `services/` est un vestige de la migration V1→V2. Son contenu correspond fonctionnellement à un repository infrastructure et un application service. Le déplacement n'a pas été priorisé car il n'introduit pas de violation de dépendance — le domaine n'en dépend pas — mais c'est un écart de nommage que j'identifie et planifie de corriger."_
+
+---
+
+### 2.5 Authentication / Authorization — ✅ conforme
+
+#### Distinction claire
+
+| Couche               | Fichier                     | Rôle                                                                                   | Question répondue |
+| -------------------- | --------------------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| **Authentification** | `authenticateMiddleware.ts` | Valide le token Bearer Azure B2C via Passport, extrait l'email (OID) dans `req.userID` | Qui es-tu ?       |
+| **Autorisation**     | `authorizeMiddleware.ts`    | Vérifie le rôle de l'utilisateur sur la ressource (stock) demandée                     | As-tu le droit ?  |
+
+#### Flux de sécurité
+
+```
+Requête → authenticationMiddleware (Passport Bearer → extrait OID)
+        → authorizeStockAccess (vérifie ownership ou rôle collaborateur)
+        → Controller
+```
+
+Le middleware d'autorisation est **resource-based** (par stock) et non global. Il accepte un `PrismaClient` optionnel pour les tests.
+
+**Cohérence DDD :** `authorizeMiddleware.ts` utilise `StockRole` (Value Object du domaine) pour appeler `hasRequiredPermission()`. La logique de permission est dans le domaine, pas dans le middleware.
+
+**Observation :** `AuthorizationRepository` dans `src/authorization/repositories/` est un accès Prisma direct (findUserByEmail, findStockById, findCollaboratorByUserAndStock) — il s'agit d'infrastructure, mais son placement dans `src/authorization/` est acceptable car il est exclusivement au service du middleware d'autorisation.
+
+---
+
+### 2.6 Config / Setup / Utils — ✅ conforme
+
+| Fichier                           | Rôle concret                                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `authConfig.ts`                   | Exporte l'objet de config Azure B2C (clientID, policyName, isB2C) lu depuis les variables d'env                                 |
+| `config/authenticationConfig.ts`  | Lecture des variables AZURE\_\* depuis `process.env`                                                                            |
+| `config/httpPortConfiguration.ts` | Résolution du port (PORT env var ou 3000 par défaut)                                                                            |
+| `config/models.ts`                | Types partagés de configuration (interfaces)                                                                                    |
+| `config/openapi.config.ts`        | Charge `docs/openapi.yaml` et produit le spec Swagger                                                                           |
+| `config/runtimeMode.ts`           | Booléen `isDevelopment` / `isProduction`                                                                                        |
+| `initializeApp.ts`                | Bootstrap complet Express : CORS, Passport, routes, Swagger, health check, error handler                                        |
+| `serverSetup/setupHttpServer.ts`  | `app.listen()` — séparé de `initializeApp` pour faciliter les tests (on peut importer `initializeApp` sans démarrer le serveur) |
+| `Utils/logger.ts`                 | Loggers nommés (rootMain, rootController, rootDatabase, rootSecurity, rootUserService…) — aucun `console.*`                     |
+| `Utils/cloudLogger.ts`            | Logger Azure Application Insights (`rootException` pour les erreurs non gérées)                                                 |
+| `Utils/express.d.ts`              | Augmentation de type `Express.Request` pour ajouter `userID?: string` et `authInfo`                                             |
+| `Utils/httpCodes.ts`              | Constantes HTTP 200 / 201                                                                                                       |
+
+**Observation :** La séparation `initializeApp` / `setupHttpServer` est un bon pattern — elle permet d'importer l'application dans les tests d'intégration sans qu'elle tente d'écouter sur un port.
+
+---
+
+## 3. Analyse CQRS
+
+### Séparation Read / Write
+
+| Côté                     | Composants                                                    | Localisation                             |
+| ------------------------ | ------------------------------------------------------------- | ---------------------------------------- |
+| **WRITE (Command side)** | 9 Commands + 9 CommandHandlers                                | `domain/stock-management/manipulation/`  |
+| **WRITE (Authz)**        | 3 Commands + 3 CommandHandlers                                | `domain/authorization/collaboration/`    |
+| **READ (Query side)**    | `IStockVisualizationRepository` + `StockVisualizationService` | `domain/stock-management/visualization/` |
+
+### Commands implémentés
+
+| Command                         | Handler                                | Déclenche historique            |
+| ------------------------------- | -------------------------------------- | ------------------------------- |
+| `CreateStockCommand`            | `CreateStockCommandHandler`            | —                               |
+| `AddItemToStockCommand`         | `AddItemToStockCommandHandler`         | ✅ via `IItemHistoryRepository` |
+| `UpdateItemCommand`             | `UpdateItemCommandHandler`             | ✅                              |
+| `UpdateItemQuantityCommand`     | `UpdateItemQuantityCommandHandler`     | ✅                              |
+| `UpdateStockCommand`            | `UpdateStockCommandHandler`            | —                               |
+| `DeleteStockCommand`            | `DeleteStockCommandHandler`            | —                               |
+| `DeleteItemCommand`             | `DeleteItemCommandHandler`             | —                               |
+| `CreateContributionCommand`     | `CreateContributionCommandHandler`     | —                               |
+| `ReviewContributionCommand`     | `ReviewContributionCommandHandler`     | —                               |
+| `AddCollaboratorCommand`        | `AddCollaboratorCommandHandler`        | —                               |
+| `UpdateCollaboratorRoleCommand` | `UpdateCollaboratorRoleCommandHandler` | —                               |
+| `RemoveCollaboratorCommand`     | `RemoveCollaboratorCommandHandler`     | —                               |
+
+### Queries implémentées
+
+| Query                              | Service                      | Description                                        |
+| ---------------------------------- | ---------------------------- | -------------------------------------------------- |
+| `getAllStocks(userId)`             | `StockVisualizationService`  | Liste des stocks de l'utilisateur avec rôle viewer |
+| `getStockDetails(stockId, userId)` | `StockVisualizationService`  | Détail d'un stock                                  |
+| `getStockItems(stockId, userId)`   | `StockVisualizationService`  | Items d'un stock avec statut                       |
+| `getItemHistory(itemId)`           | `StockPredictionController`  | Historique des variations                          |
+| `getItemPrediction(itemId)`        | `StockPredictionController`  | Prédiction déterministe                            |
+| `getStockSuggestions(stockId)`     | `StockSuggestionsController` | Suggestions LLM + déterministes                    |
+
+### Verdict CQRS
+
+La séparation read/write est **clairement établie et cohérente**. Le côté lecture n'utilise pas d'agrégats domaine — il retourne directement des DTOs depuis `IStockVisualizationRepository` (requêtes Prisma optimisées). Le côté écriture passe systématiquement par les CommandHandlers et les entités domaine.
+
+**Pas de CommandBus ni QueryBus** : le dispatch est direct (appel de méthode). C'est du CQRS pragmatique — défendable pour ce niveau de complexité (pas besoin de bus middleware pour 12 commands).
+
+---
+
+## 4. Synthèse des ADRs
+
+| ADR         | Décision                                                                     | Justification                                                                        | Alternatives rejetées                                                                           |
+| ----------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| **ADR-001** | Architecture DDD/CQRS                                                        | Démonstration RNCP + invariants métier centralisés + séparation read/write           | Transaction Script (non scalable), Active Record (couplage ORM), Event Sourcing (trop complexe) |
+| **ADR-002** | Prisma ORM                                                                   | Type-safety automatique, migrations versionnées, performance Rust, DX                | TypeORM (verbeux), Drizzle (trop récent), Sequelize (pas TypeScript-first)                      |
+| **ADR-003** | Azure AD B2C                                                                 | Authentification managée, SSO, OIDC standard                                         | Auth0 (coût), JWT maison (sécurité à gérer soi-même)                                            |
+| **ADR-004** | Tests Value Objects / Entities                                               | Logique métier testée sans DB (unitaire), intégration pour repos Prisma              | Tester uniquement via HTTP (tests trop larges)                                                  |
+| **ADR-005** | Versioning API (`/api/v2`)                                                   | Coexistence V1 legacy / V2 DDD pendant migration                                     | Pas de versioning (breaking changes immédiats)                                                  |
+| **ADR-006** | MySQL sur Azure                                                              | Base de données relationnelle, compatibilité Prisma, hébergement cloud               | PostgreSQL (moins maîtrisé), SQLite (pas prod-ready)                                            |
+| **ADR-007** | ESLint + Prettier + commitlint                                               | 0 warning, format automatique, commits conventionnels vérifiés au pre-commit         | Revue manuelle (non fiable en solo)                                                             |
+| **ADR-008** | Type aliases requêtes Express                                                | Typage fort des `req.body` / `req.params` par route                                  | `any` (non typé), validation runtime seule (Joi/Zod)                                            |
+| **ADR-009** | Autorisation resource-based hybride (OWNER/EDITOR/VIEWER/VIEWER_CONTRIBUTOR) | Contexte familial réaliste, granularité par stock                                    | RBAC global (trop rigide), ABAC (trop complexe), permissions à la carte (UX difficile)          |
+| **ADR-010** | Optimisation pipeline CI/CD                                                  | Cache npm, parallélisation unit/integration, artifacts de build                      | CI séquentiel (trop lent)                                                                       |
+| **ADR-011** | Staging sur Render.com + Aiven MySQL                                         | Déploiement automatique branche staging, DB managée, coût zéro                       | Azure staging slot (coût), env local uniquement (pas de validation déploiement)                 |
+| **ADR-012** | Node.js 22 LTS                                                               | Fetch natif, performance V8, LTS jusqu'en 2027                                       | Node 18 (plus maintenu), Node 20 (pas encore LTS long terme)                                    |
+| **ADR-013** | LLM Provider : local vs cloud                                                | OpenRouter comme agrégateur de modèles, coût variable, pas de dépendance vendor-lock | Ollama local (pas de prod), OpenAI direct (coût, vendor lock)                                   |
+| **ADR-014** | Prédictions déterministes (Niveau 1)                                         | Pas de LLM requis, calcul sur historique réel, résultats explicables                 | ML externe (complexité opérationnelle), LLM pour prédictions numériques (coût, latence)         |
+| **ADR-015** | OpenRouter + fetch natif pour AIService                                      | Zéro dépendance npm supplémentaire, compatible Node 22, maîtrise du payload          | SDK Mistral officiel (vendor lock), SDK OpenAI (inutile si OpenRouter)                          |
+| **ADR-016** | REST API                                                                     | Standard industrie, bien connu du jury, compatible OpenAPI                           | GraphQL (surcharge pour ce domaine), gRPC (pas adapté HTTP browser)                             |
+| **ADR-017** | Express 4                                                                    | Minimaliste, maîtrisé, écosystème large, compatible Passport                         | Fastify (moins de ressources), NestJS (trop opinionated, overhead DI)                           |
+| **ADR-018** | GitHub Flow                                                                  | Branches `main` + feature branches, PRs, Release Please                              | Git Flow (trop complexe pour solo), trunk-based (pas de revue possible)                         |
+
+---
+
+## 5. Couverture des tests
+
+### Répartition par type
+
+| Type                  | Localisation                | Nb fichiers | Ce qui est testé                                |
+| --------------------- | --------------------------- | ----------- | ----------------------------------------------- |
+| **Unitaires domaine** | `tests/domain/`             | 22 fichiers | Entities, VOs, CommandHandlers, Domain Services |
+| **Unitaires API**     | `tests/api/`, `tests/unit/` | 5 fichiers  | Controllers, Mappers, Routes                    |
+| **Intégration**       | `tests/integration/`        | 4 fichiers  | Repositories Prisma (TestContainers MySQL)      |
+| **E2E**               | `tests/e2e/`                | 4 fichiers  | Workflows HTTP complets (Playwright)            |
+
+### Détail couverture domaine
+
+| Composant                                                              | Tests présents                                                    |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `Stock`                                                                | `Stock.test.ts` — création, addItem, removeItem, invariants       |
+| `StockItem`                                                            | `StockItem.test.ts` — getStatus, isLowStock                       |
+| `Family`                                                               | 4 fichiers (create, info, members, roles) — couverture exhaustive |
+| `ItemContribution`                                                     | `ItemContribution.test.ts`                                        |
+| VOs `Quantity`, `StockLabel`, `StockDescription`, `ContributionStatus` | 1 fichier par VO                                                  |
+| VOs `FamilyRole`, `StockRole`                                          | 1 fichier par VO                                                  |
+| CommandHandlers manipulation                                           | 7 fichiers (tous les handlers)                                    |
+| `StockVisualizationService`                                            | `StockVisualizationService.test.ts`                               |
+| `StockPredictionService`                                               | `StockPredictionService.test.ts` (10 cas)                         |
+| `OpenRouterAIService`                                                  | `OpenRouterAIService.test.ts`                                     |
+| Collaboration handlers                                                 | 4 fichiers                                                        |
+
+### Gaps identifiés
+
+| Composant                                                    | Statut                                                                    |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `StockPredictionController`                                  | ❌ Pas de tests unitaires dédiés                                          |
+| `StockContributionController`                                | ❌ Pas de tests unitaires dédiés                                          |
+| `StockCollaboratorController`                                | ❌ Pas de tests unitaires dédiés                                          |
+| `UserService` / `ReadUserRepository` / `WriteUserRepository` | ❌ Aucun test                                                             |
+| `authorizeMiddleware`                                        | ✅ Test d'intégration présent (`authorizeMiddleware.integration.test.ts`) |
+| `PrismaStockCommandRepository`                               | ✅ Test d'intégration                                                     |
+| `PrismaStockVisualizationRepository`                         | ✅ Test d'intégration                                                     |
+
+---
+
+## 6. Violations de la règle de dépendance
+
+Règle vérifiée : `domain` ne doit pas importer depuis `infrastructure`, `api` ou `@prisma/client`.
+
+```bash
+grep -r "from.*infrastructure" src/domain → (aucun résultat)
+grep -r "from.*api" src/domain          → (aucun résultat)
+grep -r "from.*prisma" src/domain       → (aucun résultat)
+```
+
+**Résultat : aucune violation détectée.**
+
+Le domaine est totalement indépendant de l'infrastructure et de la couche API. Toutes les dépendances vont dans le bon sens : `api → domain ← infrastructure`.
+
+---
+
+## 7. Bilan et recommandations pour la soutenance
+
+### Points forts à mettre en avant au jury
+
+1. **Règle de dépendance parfaitement respectée** : le domaine est pur, sans import Prisma ni import API. Vérifiable avec une seule commande `grep`.
+
+2. **CQRS lisible et cohérent** : deux chemins distincts (manipulation/visualization), deux interfaces repository distinctes, deux controllers distincts. La séparation n'est pas théorique — elle est visible dans l'arborescence.
+
+3. **Entités avec invariants réels** : `Stock.addItem()` vérifie les doublons case-insensitive, la quantité négative. `Family.removeMember()` protège le dernier admin. Ces règles ne peuvent pas être contournées car elles sont dans le domaine, pas dans les controllers.
+
+4. **Value Objects** qui se valident à la construction : impossible de créer un `StockLabel` invalide (< 3 chars, > 50 chars) ou une `Quantity` négative.
+
+5. **Injection de dépendances sans container** : le pattern `prismaClient ?? new PrismaClient()` + factory dans `StockRoutesV2.ts` rend tout testable sans framework DI. Simple à expliquer et à défendre.
+
+6. **Module IA intégré dans l'architecture** : `IAIService` dans le domaine, `OpenRouterAIService` dans l'infrastructure. Même pattern que les repositories Prisma — l'IA est traitée comme un adaptateur externe.
+
+7. **Historique automatique** alimenté dans les CommandHandlers (pas de middleware Prisma) — traçabilité explicite et testable.
+
+8. **18 ADRs documentés** : chaque décision architecturale majeure est justifiée, avec alternatives rejetées et conséquences. Idéal pour répondre aux questions du jury ("pourquoi pas NestJS ?", "pourquoi pas TypeORM ?").
+
+### Écarts assumés à justifier
+
+| Écart                                  | Formulation orale suggérée                                                                                                                                                                                                                                                                                                                 |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/services/` mal positionné         | _"C'est un héritage de la migration V1→V2. Son contenu ne viole pas la règle de dépendance — le domaine n'en dépend pas. C'est un refactoring de nommage que j'ai identifié et priorisé pour la prochaine itération."_                                                                                                                     |
+| `Stock` accepte `string \| StockLabel` | _"C'est un compromis pragmatique : reconstituer les Value Objects à chaque lecture Prisma aurait un coût à l'exécution. Le domaine reste protégé à l'écriture (Stock.create() et addItem() utilisent les VOs), la lecture retourne des DTOs — les VOs ne sont jamais exposés côtés Query."_                                                |
+| Pas de Domain Events                   | _"Le projet n'a pas encore de besoin d'audit trail asynchrone ou d'event sourcing. L'historique est géré de manière synchrone dans les CommandHandlers, ce qui est plus simple à tester et à déboguer. Les Domain Events seraient la prochaine évolution naturelle si le domaine requiert des réactions croisées entre bounded contexts."_ |
+| Pas de CommandBus / QueryBus           | _"Le dispatch direct est suffisant pour 12 commands et une seule API. Un bus apporterait de la flexibilité (interceptors, logging transversal) mais aussi de la complexité opaque. Ce choix est documenté dans ADR-001."_                                                                                                                  |
+| `prediction` sans entité `Prediction`  | _"La prédiction est un résultat calculé, pas un objet avec identité propre et cycle de vie. Un Value Object ou un Record TypeScript est suffisant. Si les prédictions devaient avoir leur propre historique ou états (ex : VALIDATED, STALE), elles deviendraient une entité."_                                                            |
+
+### Corrections prioritaires (si temps disponible avant soutenance)
+
+| Priorité | Action                                                                     | Impact                                                         | Effort                                            |
+| -------- | -------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
+| 1        | Déplacer `src/services/` vers `infrastructure/user/` et `domain/user/`     | Cohérence architecturale visible                               | Faible (renommage + mise à jour imports)          |
+| 2        | Ajouter tests unitaires pour `StockPredictionController`                   | Couverture des controllers IA                                  | Faible (pattern identique aux autres controllers) |
+| 3        | Aligner le nom `UPDATE_ITEM_QUANTITY` dans `routePaths.ts` → `UPDATE_ITEM` | Cohérence nommage                                              | Très faible                                       |
+| 4        | Ajouter tests unitaires pour `UserService`                                 | Couverture de la logique de création automatique d'utilisateur | Moyen (besoin de mocks Prisma)                    |
+| 5        | Ajouter un TTL sur `getItemPrediction` (vérifier `generatedAt`)            | Éviter des prédictions obsolètes                               | Moyen (logique dans `StockPredictionService`)     |

--- a/docs/REPO_AUDIT.md
+++ b/docs/REPO_AUDIT.md
@@ -1,0 +1,411 @@
+# Audit Organisation — dépôt `stockhub_back` (hors `src/`)
+
+**Date :** 10 avril 2026
+**Version auditée :** v2.1.1 — branche `main`
+**Périmètre :** Tout le dépôt sauf `src/` (couvert dans `ARCHITECTURE_AUDIT.md`)
+
+---
+
+## 1. Cartographie complète (hors `src/`)
+
+```
+stockhub_back/
+│
+├── ── Fichiers de configuration racine ──
+├── package.json                      # Dépendances, scripts npm, config lint-staged et prisma seed
+├── tsconfig.json                     # TypeScript strict, path aliases, inclut src/ + tests/ + prisma/
+├── jest.config.js                    # Config Jest tests unitaires (domain + api/controllers)
+├── jest.integration.config.js        # Config Jest tests intégration (TestContainers)
+├── jest.ci.config.js                 # Config Jest CI (couverture)
+├── knip.json                         # Détection code mort (src/ + .husky/, ignore tests/)
+├── eslint.config.mjs                 # ESLint 9 flat config (0 warnings)
+├── .prettierrc / .prettierignore     # Formatage automatique
+├── commitlint.config.js              # Conventional Commits (validé par Husky)
+├── playwright.config.ts              # Config Playwright (E2E, workers=1, retries CI)
+├── nodemon.json                      # Watch src/ pour hot reload dev
+├── webpack.config.js                 # Build prod (bundle + Prisma engine copy)
+├── .nvmrc                            # Version Node.js fixée (22.x)
+├── .release-please-manifest.json     # Versioning semver automatique
+├── release-please-config.json        # Config Release Please (CHANGELOG, tag)
+│
+├── ── Déploiement & Infrastructure ──
+├── Dockerfile                        # Image Node 22, build + start prod
+├── compose.yaml                      # MySQL 8 local (port 3308), volume persistant
+├── render.yaml                       # Config Render.com (staging)
+├── build-docker-image.ps1            # Script PowerShell build image Docker local
+├── start_mysql.ps1                   # Script PowerShell démarrage MySQL local
+├── stop_mysql.ps1                    # Script PowerShell arrêt MySQL local
+│
+├── ── Sécurité & Gouvernance ──
+├── SECURITY.md                       # Politique de sécurité (signalement vulnérabilités)
+├── LICENSE                           # Licence ISC
+├── .env.example                      # Variables d'env documentées (à copier en .env)
+├── .env.staging.example              # Variables d'env staging (Render + Aiven)
+├── .env.docker                       # Variables d'env pour Docker local
+├── .env.aiven                        # Variables d'env Aiven (staging DB)
+├── .env.test                         # Variables d'env pour tests E2E
+├── .dockerignore                     # Exclut node_modules, dist, .env du build Docker
+│
+├── ── Documentation racine ──
+├── README.md                         # Présentation projet, démarrage rapide
+├── CHANGELOG.md                      # Journal des changements (auto-généré Release Please)
+├── ROADMAP.md                        # Feuille de route & features planifiées
+├── CLAUDE.md                         # Instructions pour sessions IA (Claude Code)
+│
+├── ── Outils de test API ──
+├── Stockhub_V2.postman_collection.json  # Collection Postman principale
+├── .http                             # Fichier HTTP (JetBrains/VS Code REST Client)
+│
+├── ── Dossiers générés (non versionnés) ──
+├── dist/                             # Build prod webpack (gitignored)
+├── coverage/                         # Rapport couverture Jest (gitignored)
+├── playwright-report/                # Rapport HTML Playwright (gitignored)
+├── test-results/                     # Résultats bruts Playwright (gitignored)
+│
+├── prisma/
+│   ├── schema.prisma                 # Schéma DB (9 modèles, 4 enums)
+│   ├── seed.ts                       # Seed idempotent staging/dev (90j historique IA)
+│   ├── migrations/                   # 6 migrations versionnées
+│   │   ├── 20250227000000_init/
+│   │   ├── 20260325133203_add_item_history_and_predictions/
+│   │   ├── 20260327000000_add_ai_suggestions_cache/
+│   │   ├── 20260402081108_add_item_suggestions/
+│   │   ├── 20260402082739_rename_suggestions_to_contributions/
+│   │   └── 20260405153836_add_item_updated_at/
+│   └── seeds/                        # Scripts SQL utilitaires (non prod)
+│       ├── add_missing_columns.sql
+│       └── create_test_data.sql
+│
+├── tests/
+│   ├── setupTests.ts                 # Setup global Jest (unit)
+│   ├── setupIntegrationEnv.ts        # Setup global Jest (integration)
+│   ├── __mocks__/connectionUtils.ts  # Mock legacy (vestige V1)
+│   ├── helpers/
+│   │   └── testContainerSetup.ts    # Helper TestContainers (MySQL 8, prisma db push)
+│   ├── domain/                       # Tests unitaires domaine (miroir de src/domain/)
+│   ├── api/                          # Tests unitaires controllers + routes
+│   ├── unit/                         # Tests unitaires autres (mappers)
+│   ├── integration/                  # Tests intégration (TestContainers)
+│   └── e2e/                          # Tests E2E Playwright (HTTP réels)
+│       └── helpers/azureAuth.ts     # Helper acquisition token Azure ROPC
+│
+├── docs/
+│   ├── 0-INDEX.md                    # Index principal de la documentation
+│   ├── 7-SESSIONS.md                 # Index des sessions de développement
+│   ├── openapi.yaml                  # Spec OpenAPI 3.0 (source de vérité API)
+│   ├── database-schema.md            # ERD + décisions modélisation
+│   ├── rgpd.md                       # Politique RGPD
+│   ├── authorization-phase1-summary.md # Résumé implémentation autorisation
+│   ├── ARCHITECTURE_AUDIT.md         # ← Audit architecture DDD/CQRS (ce projet)
+│   ├── adr/                          # 18 ADRs + INDEX + TEMPLATE
+│   ├── technical/                    # Guides techniques (DI, logging, tests, Azure…)
+│   ├── sessions/                     # Journaux de sessions de dev (6 sessions)
+│   ├── archive/                      # Ancienne doc (issues, PRs résolues)
+│   ├── troubleshooting/              # 4 guides de résolution de problèmes
+│   ├── ci-cd/                        # Doc workflow sécurité CI
+│   └── security/                     # Rapport vulnérabilités
+│
+├── .github/
+│   ├── CODEOWNERS                    # Propriétaires du code (review automatique)
+│   ├── PULL_REQUEST_TEMPLATE.md      # Template PR (couches DDD, test plan, closes #)
+│   ├── ISSUE_TEMPLATE/               # 3 templates d'issues + config
+│   │   ├── bug_report.yml
+│   │   ├── user_story.yml
+│   │   ├── tache_technique.yml
+│   │   └── config.yml
+│   └── workflows/
+│       ├── main_stockhub-back.yml    # CI/CD principal (lint + tests + deploy Azure)
+│       ├── release-please.yml        # Versioning semver automatique
+│       └── security-audit.yml        # Audit sécurité npm planifié
+│
+├── .husky/
+│   ├── commit-msg                    # commitlint (Conventional Commits)
+│   ├── pre-commit                    # lint-staged + tsc --noEmit
+│   └── pre-push                     # format:check + lint + knip + test:unit
+│
+├── scripts/
+│   └── synthetic-data.json           # Données synthétiques (usage à clarifier)
+│
+├── sql/
+│   └── initialize_database.sql       # Script SQL initialisation DB (legacy ?)
+│
+├── postman/
+│   ├── Stockhub_Local.postman_environment.json
+│   ├── Stockhub_Staging.postman_environment.json
+│   └── Stockhub_Prod.postman_environment.json
+│
+└── audit-results/
+    └── ia-back-feasibility-audit.md  # Audit faisabilité module IA (mars 2026)
+```
+
+---
+
+## 2. Analyse par zone
+
+### 2.1 `prisma/` — ✅ conforme
+
+#### Schéma (`schema.prisma`)
+
+9 modèles, 4 enums, entièrement cohérents avec l'architecture domaine :
+
+| Modèle Prisma       | Entité domaine correspondante                | Statut    |
+| ------------------- | -------------------------------------------- | --------- |
+| `Stock`             | `Stock` (aggregate)                          | ✅ aligné |
+| `Item`              | `StockItem`                                  | ✅ aligné |
+| `ItemHistory`       | Interface `IItemHistoryRepository`           | ✅ aligné |
+| `StockPrediction`   | Interface `IPredictionRepository`            | ✅ aligné |
+| `User`              | `readUserRepository` / `writeUserRepository` | ✅ aligné |
+| `Family`            | `Family` (aggregate domaine)                 | ✅ aligné |
+| `FamilyMember`      | `FamilyMemberData`                           | ✅ aligné |
+| `StockCollaborator` | `ICollaboratorRepository`                    | ✅ aligné |
+| `ItemContribution`  | `ItemContribution` (entité domaine)          | ✅ aligné |
+
+Enums Prisma (`StockCategory`, `FamilyRole`, `ContributionStatus`, `StockRole`) reflètent exactement les enums du domaine. Les index sont cohérents avec les patterns de requête (stockId, userId, itemId+changedAt).
+
+**Observation :** Le champ `Item.label` est `String?` (nullable) alors que le domaine interdit un label vide (`Stock.addItem` lève une erreur si label vide). Incohérence de contrainte entre DB et domaine — pas bloquant car la validation domaine intervient avant la persistance, mais un `@db.VarChar(255)` avec `NOT NULL` serait plus strict.
+
+#### Migrations
+
+6 migrations nommées lisiblement et ordonnées chronologiquement. Le nommage est explicite (`add_item_history_and_predictions`, `rename_suggestions_to_contributions`).
+
+**Observation :** Le gap temporel entre `20250227000000_init` (fév. 2025) et `20260325133203_add_item_history_and_predictions` (mars 2026) est notable — soit il y avait des migrations intermédiaires supprimées (migration squash), soit la DB initiale était gérée différemment pendant cette période.
+
+#### Seed (`prisma/seed.ts`)
+
+- Idempotent (upsert systématique, `findFirst` avant création)
+- Protégé en production (`NODE_ENV === 'production'` → throw)
+- Génère 90 jours d'historique avec profils gaussiens réalistes par item
+- Données de démo parlantes (sous-stock intentionnel sur 1 item par stock)
+- Configurable via `SEED_OWNER_EMAIL` (email réel Azure B2C en staging)
+- Déclaré dans `package.json` (`"prisma": { "seed": "ts-node ..." }`)
+
+**Observation :** Le seed utilise `console.log` (3 occurrences) — à remplacer par le logger structuré pour cohérence avec le reste du projet (règle "0 console.\*").
+
+#### `prisma/seeds/` (SQL utilitaires)
+
+`add_missing_columns.sql` et `create_test_data.sql` semblent être des scripts de maintenance manuelle ou de migration ad hoc. Leur présence ici sans documentation ni contexte est un **signal d'alerte** : si ces scripts ont déjà été appliqués en production, ils devraient être remplacés par des migrations Prisma formelles. Si ce sont des helpers locaux, ils devraient être documentés ou déplacés dans `sql/`.
+
+---
+
+### 2.2 `tests/` — ✅ conforme (avec un vestige)
+
+#### Structure globale
+
+La structure `tests/` est un **miroir de `src/`** pour les tests unitaires, ce qui est une bonne pratique :
+
+```
+tests/domain/              ← miroir de src/domain/
+tests/api/controllers/     ← miroir de src/api/controllers/
+tests/integration/         ← organisé par couche (authorization, stock-management)
+tests/e2e/                 ← organisé par feature (authorization, stock-management)
+```
+
+#### Helpers de tests
+
+| Fichier                                                        | Rôle                                             | Verdict                |
+| -------------------------------------------------------------- | ------------------------------------------------ | ---------------------- |
+| `tests/setupTests.ts`                                          | Setup global unitaire (jest.clearAllMocks, etc.) | ✅ standard            |
+| `tests/setupIntegrationEnv.ts`                                 | Setup global intégration (env vars test)         | ✅                     |
+| `tests/helpers/testContainerSetup.ts`                          | Setup/teardown MySQL TestContainers              | ✅ bien isolé          |
+| `tests/e2e/helpers/azureAuth.ts`                               | Acquisition token Azure ROPC pour E2E            | ✅ correctement isolé  |
+| `tests/domain/authorization/common/entities/Family.helpers.ts` | Helpers création `Family` pour tests             | ✅ pattern test helper |
+
+#### Vrai vestige à supprimer
+
+`tests/__mocks__/connectionUtils.ts` : mock d'un module `connectionUtils` qui n'existe plus dans le code source (supprimé lors de la migration V1→V2, issue #192). Ce fichier est mort — `knip` devrait le détecter, mais il est ignoré (`"ignore": ["tests/**/*"]` dans `knip.json`).
+
+#### Séparation unit / integration / e2e
+
+- **Unitaires** (`jest.config.js`) : `tests/domain/**/*.test.ts` + `tests/api/controllers/**/*.test.ts` — pas de DB, pas de réseau
+- **Intégration** (`jest.integration.config.js`) : `tests/integration/**/*.integration.test.ts` — TestContainers MySQL réel
+- **E2E** (`playwright.config.ts`) : `tests/e2e/` — HTTP réel sur serveur démarré
+
+Timeout intégration à 60s (justifié par le démarrage du container Docker).
+
+**Observation :** `tests/unit/api/dto/mappers/StockMapper.test.ts` est dans `tests/unit/` alors que tous les autres tests API sont dans `tests/api/`. À déplacer dans `tests/api/dto/mappers/` pour cohérence. Ce test est couvert par `jest.config.js` car son path ne correspond pas à `testMatch` actuel (`**/tests/domain/**` ou `**/tests/api/controllers/**`) — il n'est donc **pas exécuté** par `npm run test:unit`.
+
+---
+
+### 2.3 `docs/` — ✅ bien organisé (avec lacunes de mise à jour)
+
+#### Structure
+
+```
+docs/
+├── 0-INDEX.md          # Point d'entrée — index numéroté (0 à 7)
+├── adr/                # ADRs — 18 décisions + INDEX + TEMPLATE ✅
+├── technical/          # Guides techniques approfondis ✅
+├── sessions/           # Journaux de sessions (6 sessions, dernière : mars 2026) ✅
+├── archive/            # Ancienne doc archivée ✅
+├── troubleshooting/    # 4 guides de résolution ✅
+├── ci-cd/              # Doc sécurité CI ✅
+└── security/           # Rapport vulnérabilités ✅
+```
+
+#### Points forts
+
+- `0-INDEX.md` est un excellent point d'entrée — index numéroté lisible, quick links, tableaux de navigation.
+- 18 ADRs avec `INDEX.md` et `TEMPLATE.md` — pratique exemplaire pour un RNCP.
+- Les sessions de dev sont documentées chronologiquement (`YYYY-MM-DD-sujet.md`).
+- L'`openapi.yaml` est la source de vérité API, exposée via Swagger (`/api-docs`).
+
+#### Lacunes identifiées
+
+| Problème                                                                                                                                              | Impact                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `0-INDEX.md` référence `1-ARCHITECTURE.md` à `6-API-DOCUMENTATION.md` mais ces fichiers **n'existent pas** dans `docs/`                               | Liens brisés dans l'index principal |
+| `0-INDEX.md` référence `technical/dependency-injection.md`, `technical/testcontainers.md`, `technical/prisma-mapping.md` qui **n'existent pas**       | Idem                                |
+| La dernière session documentée est **mars 2026** — les sessions de février à avril 2026 (migrations IA, contributions, seed) ne sont pas journalisées | Trou dans l'historique              |
+| `docs/authorization-phase1-summary.md` existe à la racine de `docs/` — aurait sa place dans `sessions/` ou `archive/`                                 | Cohérence d'organisation            |
+| `docs/7-SESSIONS.md` et `docs/0-INDEX.md` sont présents mais les fichiers `1-` à `6-` manquent                                                        | Index incohérent                    |
+| `ARCHITECTURE_AUDIT.md` (créé aujourd'hui) n'est pas encore référencé dans `0-INDEX.md`                                                               | Document orphelin                   |
+
+---
+
+### 2.4 `.github/` — ✅ conforme et complet
+
+#### Workflows CI/CD
+
+| Workflow                 | Déclencheur               | Rôle                                                                   |
+| ------------------------ | ------------------------- | ---------------------------------------------------------------------- |
+| `main_stockhub-back.yml` | Push toutes branches + PR | CI : tsc + lint + test:unit → E2E (PR→main) → Deploy Azure (push main) |
+| `release-please.yml`     | Push main                 | Release semver automatique (CHANGELOG + tag + PR release)              |
+| `security-audit.yml`     | Planifié (cron)           | `npm audit` périodique                                                 |
+
+Le pipeline principal est bien structuré en 4 jobs avec dépendances claires :
+
+- `continuous-integration` → `e2e-tests` (PR→main uniquement)
+- `continuous-integration` → `build-and-deploy` (push main uniquement)
+- `deploy-to-staging` (workflow_dispatch uniquement — déploiement manuel)
+
+**Observation :** Le job `npm audit` dans `main_stockhub-back.yml` est **commenté** (lignes 28-31). L'audit de sécurité n'est donc exécuté que via le workflow séparé `security-audit.yml` (cron). Acceptable mais mérite d'être documenté.
+
+#### Templates
+
+- **PR template** : structure claire (couches DDD impactées, test plan, `Closes #numero`). Conforme à la convention CLAUDE.md.
+- **Issue templates** : 3 types (bug, user story, tâche technique) avec formulaires YAML structurés — évite les issues sans contexte.
+- **CODEOWNERS** : propriétaire défini → review automatique sur les PR.
+
+---
+
+### 2.5 `.husky/` — ✅ conforme et bien calé
+
+| Hook         | Commandes                                      | Moment                                 |
+| ------------ | ---------------------------------------------- | -------------------------------------- |
+| `commit-msg` | `commitlint --edit`                            | Validation format Conventional Commits |
+| `pre-commit` | `git add -u` + `lint-staged` + `tsc --noEmit`  | Auto-format + lint + vérif TypeScript  |
+| `pre-push`   | `format:check` + `lint` + `knip` + `test:unit` | Vérification qualité avant push        |
+
+La progression est logique : vérifications rapides au commit (format + types), vérifications complètes au push (tests + code mort).
+
+**Observation :** `pre-push` exécute `npm run format:check` **et** `npm run lint` alors que `pre-commit` exécute déjà `lint-staged` (qui inclut `prettier --write` + `eslint --fix`). La vérification `format:check` au push est une double sécurité défendable (catch les fichiers non stagés), mais le `lint` au push est redondant avec le `lint-staged` du commit. Non bloquant.
+
+---
+
+### 2.6 Fichiers de configuration racine — ✅ bien configurés
+
+#### `tsconfig.json`
+
+TypeScript strict activé (`strict`, `strictNullChecks`, `noImplicitAny`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, `noFallthroughCasesInSwitch`). Path aliases cohérents avec la structure `src/`.
+
+**Observation :** L'alias `@core/*` pointe vers `src/*` (racine de src). Il est utilisé dans `initializeApp.ts` pour importer `authConfig.ts`. C'est un alias "fourre-tout" qui contourne la logique des autres alias plus précis — à terme, `authConfig.ts` devrait être sous `@config/` plutôt que `@core/`.
+
+#### `jest.config.js` (unitaires)
+
+`testMatch` couvre `**/tests/domain/**/*.test.ts` et `**/tests/api/controllers/**/*.test.ts`. Les tests `tests/unit/api/dto/mappers/StockMapper.test.ts` et `tests/api/routes/StockRoutesV2.test.ts` **ne correspondent pas** à ce pattern et sont exclus de `test:unit`.
+
+- `StockRoutesV2.test.ts` est explicitement dans `testPathIgnorePatterns` → intentionnel.
+- `StockMapper.test.ts` semble omis par inadvertance.
+
+#### `jest.integration.config.js`
+
+Contient des aliases obsolètes : `@repositories/*`, `@controllers/*`, `@routes/*` (anciens chemins V1 qui n'existent plus dans `src/`). Ces aliases sont morts mais inoffensifs.
+
+#### `knip.json`
+
+`tests/**/*` est ignoré, ce qui signifie que le code mort dans `tests/` (ex: `__mocks__/connectionUtils.ts`) n'est pas détecté. Acceptable pour éviter les faux positifs sur les helpers de test, mais le mock orphelin passe sous le radar.
+
+#### `.env.example`
+
+Complet et bien commenté. Inclut toutes les variables nécessaires : DB, Azure B2C, CORS, Application Insights, port, seed, OpenRouter IA. Chaque section est annotée avec le contexte d'usage. Référence pour onboarding.
+
+---
+
+### 2.7 Déploiement & Infrastructure — ✅ cohérent
+
+| Fichier                              | Rôle                                                                               | Verdict         |
+| ------------------------------------ | ---------------------------------------------------------------------------------- | --------------- |
+| `Dockerfile`                         | Image Node 22, `npm ci --only=production` + `npm run build` + `node dist/index.js` | ✅              |
+| `compose.yaml`                       | MySQL 8 local sur port 3308, volume persistant                                     | ✅              |
+| `render.yaml`                        | Config Render.com staging (branche `staging`, env vars référencées)                | ✅              |
+| `.env.example`                       | Variables documentées, gitignored                                                  | ✅              |
+| `.env.staging.example`               | Variables staging (Aiven), gitignored                                              | ✅              |
+| `start_mysql.ps1` / `stop_mysql.ps1` | Scripts Windows dev local                                                          | ✅ utile en dev |
+| `build-docker-image.ps1`             | Build image Docker local                                                           | ✅              |
+
+**Observation :** Les scripts `.ps1` sont Windows-only. Si la CI tourne sur Ubuntu (c'est le cas — `runs-on: ubuntu-latest`), ces scripts ne sont pas utilisables en CI. Ils sont destinés au dev local Windows — acceptable, mais mérite une note dans le README.
+
+---
+
+### 2.8 Outils de test API — ⚠️ à rationaliser
+
+| Outil                  | Fichiers                                       | Verdict         |
+| ---------------------- | ---------------------------------------------- | --------------- |
+| Postman collection     | `Stockhub_V2.postman_collection.json` (racine) | ✅ utilisable   |
+| Postman environnements | `postman/` (3 fichiers : local, staging, prod) | ✅ bien séparés |
+| HTTP Client            | `.http` (fichier unique à la racine)           | ✅              |
+
+**Problème :** La collection Postman principale est à la **racine** du repo, les environnements sont dans `postman/`. Incohérence : tout devrait être dans `postman/` ou à la racine. La collection racine `Stockhub_V2.postman_collection.json` est dupliquée ou distincte de ce qui est dans `postman/` — à vérifier et consolider.
+
+---
+
+### 2.9 Dossiers divers — ⚠️ à clarifier
+
+| Dossier/Fichier               | Contenu                               | Verdict                                              |
+| ----------------------------- | ------------------------------------- | ---------------------------------------------------- |
+| `sql/initialize_database.sql` | Script SQL initialisation DB          | ⚠️ Rôle flou — supplanté par les migrations Prisma ? |
+| `scripts/synthetic-data.json` | Données synthétiques JSON             | ⚠️ Rôle non documenté — lié au seed ? aux tests ?    |
+| `audit-results/`              | Audit faisabilité IA (mars 2026)      | ✅ mais orphelin — mériterait d'être dans `docs/`    |
+| `.claude/`                    | Prompts d'audit, notes de sessions IA | ✅ usage interne, non versionné dans docs/           |
+
+---
+
+## 3. Bilan et recommandations pour la soutenance
+
+### Points forts à mettre en avant au jury
+
+1. **Pipeline CI/CD complet et lisible** : 4 jobs distincts (CI → E2E → Deploy Azure / Deploy Staging), chacun avec une condition explicite. La séparation CI/CD est visible dans un seul fichier bien commenté.
+
+2. **Triple filet qualité** : Husky (local) → CI GitHub Actions (PR) → Release Please (main). Chaque niveau a un rôle distinct.
+
+3. **Tests à 3 niveaux avec des outils adaptés à chaque niveau** : Jest + mocks pour l'unitaire, TestContainers (MySQL réel) pour l'intégration, Playwright pour l'E2E. Ce choix est justifiable : chaque outil est le meilleur de sa catégorie pour son niveau.
+
+4. **Schéma Prisma comme source de vérité DB** : 6 migrations nommées et ordonnées, `migration_lock.toml`, pas de SQL manuel en production (en théorie).
+
+5. **Gestion des secrets exemplaire** : `.env.example` documenté, `.env` gitignored, secrets Azure en GitHub Secrets, pas de credentials dans le code.
+
+6. **Templates GitHub structurés** : 3 templates d'issues (bug / user story / tech), 1 template PR avec checklist DDD — gage de qualité de gouvernance.
+
+7. **Seed de démo réaliste** : données gaussiennes sur 90 jours, sous-stocks intentionnels, collaborateur configuré — la démo jury arrive sur une app vivante et cohérente.
+
+### Écarts assumés à justifier
+
+| Écart                                                                 | Formulation orale suggérée                                                                                                                                                                                                                                            |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sql/` et `prisma/seeds/*.sql` coexistent avec les migrations Prisma  | _"Les fichiers SQL dans `sql/` et `prisma/seeds/` sont des helpers de maintenance ad hoc, pas des migrations. Toutes les évolutions de schéma en production passent par `prisma migrate deploy`. Ces scripts SQL sont des outils locaux, pas du code de production."_ |
+| `tests/__mocks__/connectionUtils.ts` orphelin                         | _"C'est un vestige de la migration V1→V2 que knip ne détecte pas car `tests/` est exclu de son périmètre. Je l'ai identifié dans cet audit — c'est une ligne de correction immédiate."_                                                                               |
+| Scripts `.ps1` Windows-only                                           | _"L'environnement de développement est Windows, la CI est Linux. Les scripts PowerShell sont uniquement des helpers dev local. La CI utilise directement les commandes npm, pas ces scripts."_                                                                        |
+| `1-ARCHITECTURE.md` à `6-API-DOCUMENTATION.md` manquants dans `docs/` | _"Ces fichiers sont référencés dans l'index mais ont été archivés ou leur contenu a été distribué dans les sous-dossiers `technical/` et `adr/`. L'index `0-INDEX.md` doit être mis à jour pour pointer vers les emplacements actuels."_                              |
+
+### Corrections prioritaires (si temps disponible avant soutenance)
+
+| Priorité | Action                                                                                                                                                                    | Impact                                 | Effort      |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------- |
+| 1        | Supprimer `tests/__mocks__/connectionUtils.ts` (mock orphelin)                                                                                                            | Propreté du repo                       | Très faible |
+| 2        | Déplacer `tests/unit/api/dto/mappers/StockMapper.test.ts` → `tests/api/dto/mappers/` et ajuster `testMatch` dans `jest.config.js`                                         | Ce test n'est pas exécuté actuellement | Faible      |
+| 3        | Mettre à jour `docs/0-INDEX.md` : supprimer les liens vers `1-ARCHITECTURE.md` → `6-API-DOCUMENTATION.md` inexistants, ajouter `ARCHITECTURE_AUDIT.md` et `REPO_AUDIT.md` | Cohérence documentation                | Faible      |
+| 4        | Consolider la collection Postman : déplacer `Stockhub_V2.postman_collection.json` dans `postman/`                                                                         | Cohérence organisation                 | Très faible |
+| 5        | Supprimer les aliases morts dans `jest.integration.config.js` (`@repositories`, `@controllers`, `@routes`)                                                                | Propreté config                        | Très faible |
+| 6        | Remplacer les `console.log` dans `prisma/seed.ts` par le logger ou `process.stdout.write`                                                                                 | Cohérence règle "0 console.\*"         | Très faible |
+| 7        | Documenter le rôle de `scripts/synthetic-data.json` et `sql/initialize_database.sql` ou les supprimer                                                                     | Clarté repo                            | Faible      |
+| 8        | Journaliser les sessions manquantes (fév → avr 2026) dans `docs/sessions/`                                                                                                | Cohérence historique                   | Moyen       |

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,6 @@ module.exports = {
     '^@utils/(.*)$': '<rootDir>/src/Utils/$1',
     '^@config/(.*)$': '<rootDir>/src/config/$1',
     '^@api/(.*)$': '<rootDir>/src/api/$1',
-    '^@services/(.*)$': '<rootDir>/src/services/$1',
     '^@authentication/(.*)$': '<rootDir>/src/authentication/$1',
     '^@authorization/(.*)$': '<rootDir>/src/authorization/$1',
     '^@serverSetup/(.*)$': '<rootDir>/src/serverSetup/$1',

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -12,7 +12,6 @@ module.exports = {
     '^@utils/(.*)$': '<rootDir>/src/Utils/$1',
     '^@config/(.*)$': '<rootDir>/src/config/$1',
     '^@api/(.*)$': '<rootDir>/src/api/$1',
-    '^@services/(.*)$': '<rootDir>/src/services/$1',
     '^@repositories/(.*)$': '<rootDir>/src/repositories/$1',
     '^@controllers/(.*)$': '<rootDir>/src/controllers/$1',
     '^@routes/(.*)$': '<rootDir>/src/routes/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4697,15 +4697,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -6327,9 +6327,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -10201,9 +10201,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -11965,11 +11965,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/src/api/controllers/StockContributionController.ts
+++ b/src/api/controllers/StockContributionController.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { AuthenticatedRequest } from '@api/types/AuthenticatedRequest';
 import { CreateContributionRequest, ReviewContributionRequest } from '@api/types/StockRequestTypes';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { CreateContributionCommandHandler } from '@domain/stock-management/manipulation/use-cases/CreateContributionCommandHandler';
 import { ReviewContributionCommandHandler } from '@domain/stock-management/manipulation/use-cases/ReviewContributionCommandHandler';
 import { CreateContributionCommand } from '@domain/stock-management/manipulation/commands/CreateContributionCommand';

--- a/src/api/controllers/StockControllerManipulation.ts
+++ b/src/api/controllers/StockControllerManipulation.ts
@@ -10,7 +10,7 @@ import {
   UpdateItemRequest,
   UpdateStockRequest,
 } from '@api/types/StockRequestTypes';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { CreateStockCommandHandler } from '@domain/stock-management/manipulation/use-cases/CreateStockCommandHandler';
 import { AddItemToStockCommandHandler } from '@domain/stock-management/manipulation/use-cases/AddItemToStockCommandHandler';
 import { UpdateItemCommandHandler } from '@domain/stock-management/manipulation/use-cases/UpdateItemCommandHandler';

--- a/src/api/controllers/StockControllerVisualization.ts
+++ b/src/api/controllers/StockControllerVisualization.ts
@@ -1,5 +1,5 @@
 import { StockVisualizationService } from '@domain/stock-management/visualization/services/StockVisualizationService';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
 import { CustomError, sendError } from '@api/errors';
 import express from 'express';

--- a/src/api/controllers/StockPredictionController.ts
+++ b/src/api/controllers/StockPredictionController.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import { AuthenticatedRequest } from '@api/types/AuthenticatedRequest';
 import { StockPredictionService } from '@domain/prediction/services/StockPredictionService';
 import { IItemHistoryRepository } from '@domain/prediction/repositories/IItemHistoryRepository';
 import { IPredictionRepository } from '@domain/prediction/repositories/IPredictionRepository';
@@ -17,7 +16,7 @@ export class StockPredictionController {
     private readonly predictionRepository: IPredictionRepository
   ) {}
 
-  public async getItemHistory(req: AuthenticatedRequest, res: express.Response): Promise<void> {
+  public async getItemHistory(req: express.Request, res: express.Response): Promise<void> {
     try {
       const itemId = Number(req.params.itemId);
       const days = Number(req.query['days'] ?? 90);
@@ -33,7 +32,7 @@ export class StockPredictionController {
     }
   }
 
-  public async getItemPrediction(req: AuthenticatedRequest, res: express.Response): Promise<void> {
+  public async getItemPrediction(req: express.Request, res: express.Response): Promise<void> {
     try {
       const itemId = Number(req.params.itemId);
       const currentQuantity = Number(req.query['quantity'] ?? 0);

--- a/src/api/controllers/StockSuggestionsController.ts
+++ b/src/api/controllers/StockSuggestionsController.ts
@@ -4,7 +4,7 @@ import { AISuggestion, IAIService } from '@domain/ai/IAIService';
 import { IPredictionRepository } from '@domain/prediction/repositories/IPredictionRepository';
 import { StockPredictionService } from '@domain/prediction/services/StockPredictionService';
 import { IStockVisualizationRepository } from '@domain/stock-management/visualization/queries/IStockVisualizationRepository';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
 import { CustomError, sendError } from '@api/errors';
 import { rootController } from '@utils/logger';

--- a/src/api/routes/StockRoutesV2.ts
+++ b/src/api/routes/StockRoutesV2.ts
@@ -179,7 +179,7 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
   logger.info('Routes for POST /stocks/:stockId/items configured (with authorization)');
 
   router.patch(
-    STOCK_ROUTES.UPDATE_ITEM_QUANTITY,
+    STOCK_ROUTES.UPDATE_ITEM,
     authorizeStockWrite,
     async (req, res: express.Response) => {
       await manipulationController.updateItem(req as UpdateItemRequest, res);

--- a/src/api/routes/StockRoutesV2.ts
+++ b/src/api/routes/StockRoutesV2.ts
@@ -1,5 +1,5 @@
 import { StockVisualizationService } from '@domain/stock-management/visualization/services/StockVisualizationService';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { StockControllerVisualization } from '@api/controllers/StockControllerVisualization';
 import { StockControllerManipulation } from '@api/controllers/StockControllerManipulation';
 import {
@@ -11,8 +11,8 @@ import {
   UpdateStockRequest,
 } from '@api/types/StockRequestTypes';
 import express, { Router } from 'express';
-import { ReadUserRepository } from '@services/readUserRepository';
-import { WriteUserRepository } from '@services/writeUserRepository';
+import { PrismaReadUserRepository } from '@infrastructure/user/repositories/PrismaReadUserRepository';
+import { PrismaWriteUserRepository } from '@infrastructure/user/repositories/PrismaWriteUserRepository';
 import { PrismaStockVisualizationRepository } from '@infrastructure/stock-management/visualization/repositories/PrismaStockVisualizationRepository';
 import { PrismaStockCommandRepository } from '@infrastructure/stock-management/manipulation/repositories/PrismaStockCommandRepository';
 import { CreateStockCommandHandler } from '@domain/stock-management/manipulation/use-cases/CreateStockCommandHandler';
@@ -60,8 +60,8 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
 
   const stockVisualizationService = new StockVisualizationService(prismaRepository);
 
-  const readUserRepo = new ReadUserRepository();
-  const writeUserRepo = new WriteUserRepository();
+  const readUserRepo = new PrismaReadUserRepository();
+  const writeUserRepo = new PrismaWriteUserRepository();
   const userService = new UserService(readUserRepo, writeUserRepo);
 
   const stockController = new StockControllerVisualization(stockVisualizationService, userService);

--- a/src/api/routes/constants/routePaths.ts
+++ b/src/api/routes/constants/routePaths.ts
@@ -18,8 +18,8 @@ export const STOCK_ROUTES = {
   /** POST - Add item to stock (requires write permission) */
   ADD_ITEM: '/stocks/:stockId/items',
 
-  /** PATCH - Update item quantity (requires write permission) */
-  UPDATE_ITEM_QUANTITY: '/stocks/:stockId/items/:itemId',
+  /** PATCH - Update item (label, description, quantity — requires write permission) */
+  UPDATE_ITEM: '/stocks/:stockId/items/:itemId',
 
   /** DELETE - Remove an item from a stock (requires write permission) */
   DELETE_ITEM: '/stocks/:stockId/items/:itemId',

--- a/src/authentication/authBearerStrategy.ts
+++ b/src/authentication/authBearerStrategy.ts
@@ -2,9 +2,9 @@ import passportAzureAd, { ITokenPayload, VerifyCallback } from 'passport-azure-a
 import express from 'express';
 import { rootMain } from '@utils/logger';
 
-import { ReadUserRepository } from '@services/readUserRepository';
-import { WriteUserRepository } from '@services/writeUserRepository';
-import { UserService } from '@services/userService';
+import { PrismaReadUserRepository } from '@infrastructure/user/repositories/PrismaReadUserRepository';
+import { PrismaWriteUserRepository } from '@infrastructure/user/repositories/PrismaWriteUserRepository';
+import { UserService } from '@domain/user/services/UserService';
 import { authConfigoptions } from '@config/authenticationConfig';
 
 interface AzureB2CTokenPayload extends ITokenPayload {
@@ -13,8 +13,8 @@ interface AzureB2CTokenPayload extends ITokenPayload {
 }
 
 async function createUserService() {
-  const readUserRepository = new ReadUserRepository();
-  const writeUserRepository = new WriteUserRepository();
+  const readUserRepository = new PrismaReadUserRepository();
+  const writeUserRepository = new PrismaWriteUserRepository();
 
   return new UserService(readUserRepository, writeUserRepository);
 }

--- a/src/domain/user/repositories/IReadUserRepository.ts
+++ b/src/domain/user/repositories/IReadUserRepository.ts
@@ -1,0 +1,3 @@
+export interface IReadUserRepository {
+  readUserByOID(oid: string): Promise<number | undefined>;
+}

--- a/src/domain/user/repositories/IWriteUserRepository.ts
+++ b/src/domain/user/repositories/IWriteUserRepository.ts
@@ -1,0 +1,3 @@
+export interface IWriteUserRepository {
+  addUser(email: string): Promise<void>;
+}

--- a/src/domain/user/services/UserService.ts
+++ b/src/domain/user/services/UserService.ts
@@ -1,5 +1,5 @@
-import { ReadUserRepository } from '@services/readUserRepository';
-import { WriteUserRepository } from '@services/writeUserRepository';
+import { IReadUserRepository } from '@domain/user/repositories/IReadUserRepository';
+import { IWriteUserRepository } from '@domain/user/repositories/IWriteUserRepository';
 import { rootUserService } from '@utils/logger';
 
 class UserIdentifier {
@@ -13,10 +13,10 @@ class UserIdentifier {
 }
 
 export class UserService {
-  private readUserRepository: ReadUserRepository;
-  private writeUserRepository: WriteUserRepository;
+  private readUserRepository: IReadUserRepository;
+  private writeUserRepository: IWriteUserRepository;
 
-  constructor(readUser: ReadUserRepository, writeUser: WriteUserRepository) {
+  constructor(readUser: IReadUserRepository, writeUser: IWriteUserRepository) {
     this.readUserRepository = readUser;
     this.writeUserRepository = writeUser;
   }

--- a/src/infrastructure/user/repositories/PrismaReadUserRepository.ts
+++ b/src/infrastructure/user/repositories/PrismaReadUserRepository.ts
@@ -1,7 +1,8 @@
 import { PrismaClient } from '@prisma/client';
+import { IReadUserRepository } from '@domain/user/repositories/IReadUserRepository';
 import { rootReadUserRepository } from '@utils/logger';
 
-export class ReadUserRepository {
+export class PrismaReadUserRepository implements IReadUserRepository {
   private prisma: PrismaClient;
 
   constructor(prismaClient?: PrismaClient) {

--- a/src/infrastructure/user/repositories/PrismaWriteUserRepository.ts
+++ b/src/infrastructure/user/repositories/PrismaWriteUserRepository.ts
@@ -1,7 +1,8 @@
 import { PrismaClient } from '@prisma/client';
+import { IWriteUserRepository } from '@domain/user/repositories/IWriteUserRepository';
 import { rootDatabase } from '@utils/logger';
 
-export class WriteUserRepository {
+export class PrismaWriteUserRepository implements IWriteUserRepository {
   private prisma: PrismaClient;
 
   constructor(prismaClient?: PrismaClient) {

--- a/tests/api/controllers/StockControllerVisualization.test.ts
+++ b/tests/api/controllers/StockControllerVisualization.test.ts
@@ -5,11 +5,10 @@ import {
   StockSummaryDto,
   StockDetailDto,
 } from '@domain/stock-management/visualization/models/StockSummary';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
-import { ReadUserRepository } from '@services/readUserRepository';
-import { WriteUserRepository } from '@services/writeUserRepository';
-import { PoolConnection } from 'mysql2/promise';
+import { PrismaReadUserRepository } from '@infrastructure/user/repositories/PrismaReadUserRepository';
+import { PrismaWriteUserRepository } from '@infrastructure/user/repositories/PrismaWriteUserRepository';
 import { Request, Response } from 'express';
 
 jest.mock('@domain/stock-management/visualization/services/StockVisualizationService');
@@ -23,18 +22,16 @@ describe('StockControllerVisualization', () => {
   let res: jest.Mocked<Response>;
   let mockStockService: jest.Mocked<StockVisualizationService>;
   let mockUserService: jest.Mocked<UserService>;
-  let mockReadUserRepo: jest.Mocked<ReadUserRepository>;
-  let mockWriteUserRepo: jest.Mocked<WriteUserRepository>;
+  let mockReadUserRepo: jest.Mocked<PrismaReadUserRepository>;
+  let mockWriteUserRepo: jest.Mocked<PrismaWriteUserRepository>;
 
   beforeEach(() => {
     mockReadUserRepo = {
-      connection: {} as PoolConnection,
       readUserByOID: jest.fn().mockResolvedValue(1),
-    } as unknown as jest.Mocked<ReadUserRepository>;
+    } as unknown as jest.Mocked<PrismaReadUserRepository>;
     mockWriteUserRepo = {
-      connection: {} as PoolConnection,
-      writeUser: jest.fn().mockResolvedValue(1),
-    } as unknown as jest.Mocked<WriteUserRepository>;
+      addUser: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<PrismaWriteUserRepository>;
     mockStockService = new StockVisualizationService(
       {} as any
     ) as jest.Mocked<StockVisualizationService>;

--- a/tests/api/controllers/StockPredictionController.test.ts
+++ b/tests/api/controllers/StockPredictionController.test.ts
@@ -1,0 +1,198 @@
+import { StockPredictionController } from '@api/controllers/StockPredictionController';
+import { sendError } from '@api/errors';
+import {
+  IItemHistoryRepository,
+  ItemHistoryRecord,
+} from '@domain/prediction/repositories/IItemHistoryRepository';
+import {
+  IPredictionRepository,
+  PredictionResult,
+} from '@domain/prediction/repositories/IPredictionRepository';
+import { StockPredictionService } from '@domain/prediction/services/StockPredictionService';
+import { HTTP_CODE_OK } from '@utils/httpCodes';
+import { Request, Response } from 'express';
+
+jest.mock('@api/errors', () => ({ sendError: jest.fn() }));
+jest.mock('@utils/cloudLogger', () => ({ rootException: jest.fn() }));
+
+const makePrediction = (overrides: Partial<PredictionResult> = {}): PredictionResult => ({
+  itemId: 1,
+  daysUntilEmpty: 15,
+  avgDailyConsumption: 2.5,
+  trend: 'STABLE',
+  recommendedRestock: 30,
+  simulatedFallback: false,
+  generatedAt: new Date('2026-04-10'),
+  ...overrides,
+});
+
+const makeHistoryRecord = (overrides: Partial<ItemHistoryRecord> = {}): ItemHistoryRecord => ({
+  id: 1,
+  itemId: 1,
+  oldQuantity: 10,
+  newQuantity: 8,
+  changeType: 'CONSUMPTION',
+  changedBy: 'user@test.com',
+  changedAt: new Date('2026-04-10'),
+  ...overrides,
+});
+
+describe('StockPredictionController', () => {
+  let controller: StockPredictionController;
+  let req: Partial<Request>;
+  let res: jest.Mocked<Response>;
+  let mockHistoryRepository: jest.Mocked<IItemHistoryRepository>;
+  let mockPredictionRepository: jest.Mocked<IPredictionRepository>;
+  let mockPredictionService: jest.Mocked<StockPredictionService>;
+
+  beforeEach(() => {
+    mockHistoryRepository = {
+      record: jest.fn(),
+      getHistory: jest.fn(),
+    };
+
+    mockPredictionRepository = {
+      save: jest.fn(),
+      getLatest: jest.fn(),
+      saveAISuggestions: jest.fn(),
+      getCachedAISuggestions: jest.fn(),
+    };
+
+    mockPredictionService = {
+      computeAndSave: jest.fn(),
+      hasSufficientHistory: jest.fn(),
+      avgDailyConsumption: jest.fn(),
+      daysUntilEmpty: jest.fn(),
+      detectTrend: jest.fn(),
+      recommendedRestockQuantity: jest.fn(),
+    } as unknown as jest.Mocked<StockPredictionService>;
+
+    controller = new StockPredictionController(
+      mockPredictionService,
+      mockHistoryRepository,
+      mockPredictionRepository
+    );
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as jest.Mocked<Response>;
+
+    jest.clearAllMocks();
+  });
+
+  describe('getItemHistory', () => {
+    describe('nominal case', () => {
+      it('should return 200 and the history records', async () => {
+        const records = [makeHistoryRecord(), makeHistoryRecord({ id: 2, changeType: 'RESTOCK' })];
+        mockHistoryRepository.getHistory.mockResolvedValue(records);
+
+        req = { params: { itemId: '1' }, query: {} };
+
+        await controller.getItemHistory(req as Request, res);
+
+        expect(mockHistoryRepository.getHistory).toHaveBeenCalledWith(1, 90);
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(records);
+      });
+
+      it('should use the days query parameter when provided', async () => {
+        mockHistoryRepository.getHistory.mockResolvedValue([]);
+
+        req = { params: { itemId: '5' }, query: { days: '30' } };
+
+        await controller.getItemHistory(req as Request, res);
+
+        expect(mockHistoryRepository.getHistory).toHaveBeenCalledWith(5, 30);
+      });
+    });
+
+    describe('empty history', () => {
+      it('should return 200 with an empty array when no records exist', async () => {
+        mockHistoryRepository.getHistory.mockResolvedValue([]);
+
+        req = { params: { itemId: '1' }, query: {} };
+
+        await controller.getItemHistory(req as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith([]);
+      });
+    });
+
+    describe('error case', () => {
+      it('should call sendError when the repository throws', async () => {
+        const error = new Error('DB connection failed');
+        mockHistoryRepository.getHistory.mockRejectedValue(error);
+
+        req = { params: { itemId: '1' }, query: {} };
+
+        await controller.getItemHistory(req as Request, res);
+
+        expect(sendError).toHaveBeenCalledWith(res, error);
+      });
+    });
+  });
+
+  describe('getItemPrediction', () => {
+    describe('cached prediction', () => {
+      it('should return 200 with the cached prediction without computing', async () => {
+        const cached = makePrediction();
+        mockPredictionRepository.getLatest.mockResolvedValue(cached);
+
+        req = { params: { itemId: '1' }, query: {} };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(mockPredictionRepository.getLatest).toHaveBeenCalledWith(1);
+        expect(mockPredictionService.computeAndSave).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(cached);
+      });
+    });
+
+    describe('no cached prediction', () => {
+      it('should compute and return 200 when no prediction is cached', async () => {
+        const computed = makePrediction({ simulatedFallback: true });
+        mockPredictionRepository.getLatest.mockResolvedValue(null);
+        mockPredictionService.computeAndSave.mockResolvedValue(computed);
+
+        req = {
+          params: { itemId: '2' },
+          query: { quantity: '10', minimumStock: '3' },
+        };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(2, 10, 3);
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(computed);
+      });
+
+      it('should use default quantity=0 and minimumStock=1 when not provided', async () => {
+        const computed = makePrediction();
+        mockPredictionRepository.getLatest.mockResolvedValue(null);
+        mockPredictionService.computeAndSave.mockResolvedValue(computed);
+
+        req = { params: { itemId: '3' }, query: {} };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(3, 0, 1);
+      });
+    });
+
+    describe('error case', () => {
+      it('should call sendError when the repository throws', async () => {
+        const error = new Error('Prediction service unavailable');
+        mockPredictionRepository.getLatest.mockRejectedValue(error);
+
+        req = { params: { itemId: '1' }, query: {} };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(sendError).toHaveBeenCalledWith(res, error);
+      });
+    });
+  });
+});

--- a/tests/api/controllers/StockSuggestionsController.test.ts
+++ b/tests/api/controllers/StockSuggestionsController.test.ts
@@ -4,7 +4,7 @@ import { IAIService } from '@domain/ai/IAIService';
 import { IPredictionRepository } from '@domain/prediction/repositories/IPredictionRepository';
 import { StockPredictionService } from '@domain/prediction/services/StockPredictionService';
 import { IStockVisualizationRepository } from '@domain/stock-management/visualization/queries/IStockVisualizationRepository';
-import { UserService } from '@services/userService';
+import { UserService } from '@domain/user/services/UserService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
 import { Request, Response } from 'express';
 

--- a/tests/domain/user/services/UserService.test.ts
+++ b/tests/domain/user/services/UserService.test.ts
@@ -1,0 +1,103 @@
+import { IReadUserRepository } from '@domain/user/repositories/IReadUserRepository';
+import { IWriteUserRepository } from '@domain/user/repositories/IWriteUserRepository';
+import { UserService } from '@domain/user/services/UserService';
+
+jest.mock('@utils/logger', () => ({
+  rootUserService: { info: jest.fn(), error: jest.fn() },
+}));
+
+// Note: no OID validation guard - empty OID creates a user with empty email.
+// Input validation is a future improvement.
+
+describe('UserService', () => {
+  let mockReadUserRepository: jest.Mocked<IReadUserRepository>;
+  let mockWriteUserRepository: jest.Mocked<IWriteUserRepository>;
+  let userService: UserService;
+
+  beforeEach(() => {
+    mockReadUserRepository = { readUserByOID: jest.fn() };
+    mockWriteUserRepository = { addUser: jest.fn() };
+    userService = new UserService(mockReadUserRepository, mockWriteUserRepository);
+    jest.clearAllMocks();
+  });
+
+  describe('convertOIDtoUserID', () => {
+    describe('existing user', () => {
+      it('should return the internal ID without calling the write repository', async () => {
+        mockReadUserRepository.readUserByOID.mockResolvedValue(42);
+
+        const result = await userService.convertOIDtoUserID('user@example.com');
+
+        expect(mockReadUserRepository.readUserByOID).toHaveBeenCalledWith('user@example.com');
+        expect(mockWriteUserRepository.addUser).not.toHaveBeenCalled();
+        expect(result.value).toBe(42);
+        expect(result.empty).toBe(false);
+      });
+    });
+
+    describe('new user', () => {
+      it('should create the user and return the new internal ID', async () => {
+        mockReadUserRepository.readUserByOID
+          .mockResolvedValueOnce(undefined) // first call: user not found
+          .mockResolvedValueOnce(undefined) // addUser re-checks existence
+          .mockResolvedValueOnce(99); // convertOIDtoUserID call inside addUser
+        mockWriteUserRepository.addUser.mockResolvedValue(undefined);
+
+        const result = await userService.convertOIDtoUserID('new@example.com');
+
+        expect(mockWriteUserRepository.addUser).toHaveBeenCalledWith('new@example.com');
+        expect(result.value).toBe(99);
+        expect(result.empty).toBe(false);
+      });
+    });
+
+    describe('error cases', () => {
+      it('should propagate an error from the read repository', async () => {
+        const error = new Error('DB connection failed');
+        mockReadUserRepository.readUserByOID.mockRejectedValue(error);
+
+        await expect(userService.convertOIDtoUserID('user@example.com')).rejects.toThrow(
+          'DB connection failed'
+        );
+      });
+
+      it('should propagate an error from the write repository', async () => {
+        const error = new Error('Upsert failed');
+        mockReadUserRepository.readUserByOID.mockResolvedValue(undefined);
+        mockWriteUserRepository.addUser.mockRejectedValue(error);
+
+        await expect(userService.convertOIDtoUserID('user@example.com')).rejects.toThrow(
+          'Upsert failed'
+        );
+      });
+    });
+  });
+
+  describe('addUser', () => {
+    describe('idempotency', () => {
+      it('should not call the write repository if the user already exists', async () => {
+        mockReadUserRepository.readUserByOID.mockResolvedValue(7);
+
+        const result = await userService.addUser('existing@example.com');
+
+        expect(mockWriteUserRepository.addUser).not.toHaveBeenCalled();
+        expect(result.value).toBe(7);
+      });
+    });
+
+    describe('new user', () => {
+      it('should write and return the created user ID', async () => {
+        mockReadUserRepository.readUserByOID
+          .mockResolvedValueOnce(undefined) // addUser existence check
+          .mockResolvedValueOnce(undefined) // convertOIDtoUserID check
+          .mockResolvedValueOnce(55); // convertOIDtoUserID -> addUser -> convertOIDtoUserID
+        mockWriteUserRepository.addUser.mockResolvedValue(undefined);
+
+        const result = await userService.addUser('brand-new@example.com');
+
+        expect(mockWriteUserRepository.addUser).toHaveBeenCalledWith('brand-new@example.com');
+        expect(result.value).toBe(55);
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
       "@utils/*": ["src/Utils/*"],
       "@config/*": ["src/config/*"],
       "@api/*": ["src/api/*"],
-      "@services/*": ["src/services/*"],
       "@authentication/*": ["src/authentication/*"],
       "@authorization/*": ["src/authorization/*"],
       "@serverSetup/*": ["src/serverSetup/*"],


### PR DESCRIPTION
## Contexte

Audit complet de l'architecture DDD/CQRS réalisé en préparation de la soutenance RNCP niveau 7.
Quatre points de correction identifiés, tous traités dans cette PR.

## Changements

### Point 1 — Suppression de `src/services/` (couche orpheline)
- Création des interfaces `IReadUserRepository` / `IWriteUserRepository` dans `src/domain/user/repositories/`
- Déplacement de `UserService` vers `src/domain/user/services/UserService.ts` avec injection des interfaces (DIP)
- Déplacement des implémentations Prisma vers `src/infrastructure/user/repositories/PrismaReadUserRepository.ts` et `PrismaWriteUserRepository.ts`
- Mise à jour de tous les points d'injection : `StockRoutesV2`, `authBearerStrategy`, controllers concernés
- Suppression de l'alias `@services/*` de `tsconfig.json`, `jest.config.js`, `jest.integration.config.js`

### Point 2 — Renommage de route
- `STOCK_ROUTES.UPDATE_ITEM_QUANTITY` → `STOCK_ROUTES.UPDATE_ITEM` dans `routePaths.ts` et `StockRoutesV2.ts`

### Point 3 — Tests unitaires manquants
- Ajout de `tests/api/controllers/StockPredictionController.test.ts` (8 tests)
- Ajout de `tests/domain/user/services/UserService.test.ts` (6 tests, coverage 100%)
- Fix : suppression de `AuthenticatedRequest` dans `StockPredictionController` (`userID` non utilisé)

### Point 4 — Documentation
- Ajout de `docs/ARCHITECTURE_AUDIT.md` et `docs/REPO_AUDIT.md`
- Mise à jour de `CLAUDE.md` : section association GitHub Project obligatoire

## Couches DDD impactées

- `domain/user/` — interfaces repositories + UserService
- `infrastructure/user/` — implémentations Prisma
- `api/controllers/` — fix signature StockPredictionController
- `api/routes/` — renommage UPDATE_ITEM

## Issues liées

- Closes #194
- Identified for future: #195 (validation itemId), #196 (404 prédiction manquante)

## Test plan

- [x] `npm run test:unit` — 266 tests, 0 échec
- [x] `npm run lint` — 0 warning
- [x] `tsc --noEmit` — 0 erreur
- [x] `grep -rn "from.*infrastructure" src/domain` — 0 résultat (règle DDD respectée)