### PR TITLE
test(controllers): add unit tests for contribution and collaborator — closes #204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,28 @@
 
 ## [2.10.1](https://github.com/SandrineCipolla/stockhub_back/compare/v2.10.0...v2.10.1) (2026-04-14)
 
-
 ### 🐛 Bug Fixes
 
-* **coverage:** restrict collectCoverageFrom to domain and controllers — refs [#199](https://github.com/SandrineCipolla/stockhub_back/issues/199) ([#203](https://github.com/SandrineCipolla/stockhub_back/issues/203)) ([e356325](https://github.com/SandrineCipolla/stockhub_back/commit/e3563254d37cef2f32949afdc69f87864377f02a))
-* **prediction:** remove unused AuthenticatedRequest from StockPredictionController ([bc64b66](https://github.com/SandrineCipolla/stockhub_back/commit/bc64b6607f028242622a8cad26475b40093bbac0))
-
+- **coverage:** restrict collectCoverageFrom to domain and controllers — refs [#199](https://github.com/SandrineCipolla/stockhub_back/issues/199) ([#203](https://github.com/SandrineCipolla/stockhub_back/issues/203)) ([e356325](https://github.com/SandrineCipolla/stockhub_back/commit/e3563254d37cef2f32949afdc69f87864377f02a))
+- **prediction:** remove unused AuthenticatedRequest from StockPredictionController ([bc64b66](https://github.com/SandrineCipolla/stockhub_back/commit/bc64b6607f028242622a8cad26475b40093bbac0))
 
 ### ♻️ Code Refactoring
 
-* **arch:** align src/ with DDD/CQRS layers — closes [#194](https://github.com/SandrineCipolla/stockhub_back/issues/194) ([#197](https://github.com/SandrineCipolla/stockhub_back/issues/197)) ([bc64b66](https://github.com/SandrineCipolla/stockhub_back/commit/bc64b6607f028242622a8cad26475b40093bbac0))
-* **domain:** rename manipulation folders — closes [#189](https://github.com/SandrineCipolla/stockhub_back/issues/189) ([#190](https://github.com/SandrineCipolla/stockhub_back/issues/190)) ([017ee49](https://github.com/SandrineCipolla/stockhub_back/commit/017ee49474bc2bd95904dc3df497ae21fc744ba7))
-* **tests:** remove redundant getValue happy-path tests on VOs — closes [#187](https://github.com/SandrineCipolla/stockhub_back/issues/187) ([#188](https://github.com/SandrineCipolla/stockhub_back/issues/188)) ([9c6bddf](https://github.com/SandrineCipolla/stockhub_back/commit/9c6bddf69a5443f1e9f8150d965721f620de975e))
-
+- **arch:** align src/ with DDD/CQRS layers — closes [#194](https://github.com/SandrineCipolla/stockhub_back/issues/194) ([#197](https://github.com/SandrineCipolla/stockhub_back/issues/197)) ([bc64b66](https://github.com/SandrineCipolla/stockhub_back/commit/bc64b6607f028242622a8cad26475b40093bbac0))
+- **domain:** rename manipulation folders — closes [#189](https://github.com/SandrineCipolla/stockhub_back/issues/189) ([#190](https://github.com/SandrineCipolla/stockhub_back/issues/190)) ([017ee49](https://github.com/SandrineCipolla/stockhub_back/commit/017ee49474bc2bd95904dc3df497ae21fc744ba7))
+- **tests:** remove redundant getValue happy-path tests on VOs — closes [#187](https://github.com/SandrineCipolla/stockhub_back/issues/187) ([#188](https://github.com/SandrineCipolla/stockhub_back/issues/188)) ([9c6bddf](https://github.com/SandrineCipolla/stockhub_back/commit/9c6bddf69a5443f1e9f8150d965721f620de975e))
 
 ### 📚 Documentation
 
-* **adr:** add ADR-016 REST, ADR-017 Express, ADR-018 GitHub Flow — closes [#181](https://github.com/SandrineCipolla/stockhub_back/issues/181) [#182](https://github.com/SandrineCipolla/stockhub_back/issues/182) [#183](https://github.com/SandrineCipolla/stockhub_back/issues/183) ([#184](https://github.com/SandrineCipolla/stockhub_back/issues/184)) ([4c12ebe](https://github.com/SandrineCipolla/stockhub_back/commit/4c12ebe68bb035a415a20d035f8bfb879a505e47))
-* **adr:** clarify V1 context and add versioning best practices in ADR-005 ([#186](https://github.com/SandrineCipolla/stockhub_back/issues/186)) ([92873be](https://github.com/SandrineCipolla/stockhub_back/commit/92873be03867e2ab74fda1103c8fd586e339df68))
-* **readme:** update architecture diagram to reflect [#194](https://github.com/SandrineCipolla/stockhub_back/issues/194) changes ([#202](https://github.com/SandrineCipolla/stockhub_back/issues/202)) ([1b91348](https://github.com/SandrineCipolla/stockhub_back/commit/1b91348424b4d4d39acef3ddf4107874f3607fa1))
-* **readme:** update README — closes [#198](https://github.com/SandrineCipolla/stockhub_back/issues/198) ([#200](https://github.com/SandrineCipolla/stockhub_back/issues/200)) ([89c3173](https://github.com/SandrineCipolla/stockhub_back/commit/89c3173e5055a12d42c882fcc64093bc3d8edf25))
-
+- **adr:** add ADR-016 REST, ADR-017 Express, ADR-018 GitHub Flow — closes [#181](https://github.com/SandrineCipolla/stockhub_back/issues/181) [#182](https://github.com/SandrineCipolla/stockhub_back/issues/182) [#183](https://github.com/SandrineCipolla/stockhub_back/issues/183) ([#184](https://github.com/SandrineCipolla/stockhub_back/issues/184)) ([4c12ebe](https://github.com/SandrineCipolla/stockhub_back/commit/4c12ebe68bb035a415a20d035f8bfb879a505e47))
+- **adr:** clarify V1 context and add versioning best practices in ADR-005 ([#186](https://github.com/SandrineCipolla/stockhub_back/issues/186)) ([92873be](https://github.com/SandrineCipolla/stockhub_back/commit/92873be03867e2ab74fda1103c8fd586e339df68))
+- **readme:** update architecture diagram to reflect [#194](https://github.com/SandrineCipolla/stockhub_back/issues/194) changes ([#202](https://github.com/SandrineCipolla/stockhub_back/issues/202)) ([1b91348](https://github.com/SandrineCipolla/stockhub_back/commit/1b91348424b4d4d39acef3ddf4107874f3607fa1))
+- **readme:** update README — closes [#198](https://github.com/SandrineCipolla/stockhub_back/issues/198) ([#200](https://github.com/SandrineCipolla/stockhub_back/issues/200)) ([89c3173](https://github.com/SandrineCipolla/stockhub_back/commit/89c3173e5055a12d42c882fcc64093bc3d8edf25))
 
 ### 🔧 Chores
 
-* **ci:** integrate Codecov for dynamic coverage badge — closes [#199](https://github.com/SandrineCipolla/stockhub_back/issues/199) ([#201](https://github.com/SandrineCipolla/stockhub_back/issues/201)) ([b645c13](https://github.com/SandrineCipolla/stockhub_back/commit/b645c133f933220bf97850c2c3beb1977622470e))
-* remove V1 code and migrate UserService to Prisma — closes [#192](https://github.com/SandrineCipolla/stockhub_back/issues/192) ([#193](https://github.com/SandrineCipolla/stockhub_back/issues/193)) ([c22d07e](https://github.com/SandrineCipolla/stockhub_back/commit/c22d07e4550f532c0d25ee999f8018ff1c86cdb4))
+- **ci:** integrate Codecov for dynamic coverage badge — closes [#199](https://github.com/SandrineCipolla/stockhub_back/issues/199) ([#201](https://github.com/SandrineCipolla/stockhub_back/issues/201)) ([b645c13](https://github.com/SandrineCipolla/stockhub_back/commit/b645c133f933220bf97850c2c3beb1977622470e))
+- remove V1 code and migrate UserService to Prisma — closes [#192](https://github.com/SandrineCipolla/stockhub_back/issues/192) ([#193](https://github.com/SandrineCipolla/stockhub_back/issues/193)) ([c22d07e](https://github.com/SandrineCipolla/stockhub_back/commit/c22d07e4550f532c0d25ee999f8018ff1c86cdb4))
 
 ## [2.10.0](https://github.com/SandrineCipolla/stockhub_back/compare/v2.9.0...v2.10.0) (2026-04-05)
 

--- a/tests/api/controllers/StockCollaboratorController.test.ts
+++ b/tests/api/controllers/StockCollaboratorController.test.ts
@@ -1,9 +1,6 @@
 import { Response } from 'express';
 import { StockCollaboratorController } from '@api/controllers/StockCollaboratorController';
-import {
-  ICollaboratorRepository,
-  CollaboratorData,
-} from '@domain/authorization/collaboration/repositories/ICollaboratorRepository';
+import { ICollaboratorRepository } from '@domain/authorization/collaboration/repositories/ICollaboratorRepository';
 import { AddCollaboratorCommandHandler } from '@domain/authorization/collaboration/command-handlers/AddCollaboratorCommandHandler';
 import { UpdateCollaboratorRoleCommandHandler } from '@domain/authorization/collaboration/command-handlers/UpdateCollaboratorRoleCommandHandler';
 import { RemoveCollaboratorCommandHandler } from '@domain/authorization/collaboration/command-handlers/RemoveCollaboratorCommandHandler';
@@ -14,24 +11,15 @@ import {
   UpdateCollaboratorRequest,
   RemoveCollaboratorRequest,
 } from '@api/types/StockRequestTypes';
+import { makeCollaborator } from '../../fixtures/collaborator.fixtures';
 
 jest.mock('@utils/logger', () => ({
   rootController: { getChildCategory: () => ({ info: jest.fn(), error: jest.fn() }) },
 }));
 
-const makeCollaborator = (overrides: Partial<CollaboratorData> = {}): CollaboratorData => ({
-  id: 1,
-  stockId: 2,
-  userId: 10,
-  userEmail: 'collab@test.com',
-  role: 'EDITOR',
-  grantedAt: new Date('2026-04-10'),
-  grantedBy: 5,
-  ...overrides,
-});
-
 describe('StockCollaboratorController', () => {
   let controller: StockCollaboratorController;
+  let req: Partial<AuthorizedRequest>;
   let res: jest.Mocked<Response>;
   let mockRepository: jest.Mocked<ICollaboratorRepository>;
   let mockAddHandler: jest.Mocked<Pick<AddCollaboratorCommandHandler, 'handle'>>;
@@ -78,9 +66,9 @@ describe('StockCollaboratorController', () => {
         ];
         mockRepository.findByStockId.mockResolvedValue(collaborators);
 
-        const req = { params: { stockId: '2' } } as unknown as AuthorizedRequest;
+        req = { params: { stockId: '2' } };
 
-        await controller.listCollaborators(req, res);
+        await controller.listCollaborators(req as AuthorizedRequest, res);
 
         expect(mockRepository.findByStockId).toHaveBeenCalledWith(2);
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
@@ -92,9 +80,9 @@ describe('StockCollaboratorController', () => {
       it('should return 500 when the repository throws', async () => {
         mockRepository.findByStockId.mockRejectedValue(new Error('DB error'));
 
-        const req = { params: { stockId: '2' } } as unknown as AuthorizedRequest;
+        req = { params: { stockId: '2' } };
 
-        await controller.listCollaborators(req, res);
+        await controller.listCollaborators(req as AuthorizedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(500);
         expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
@@ -108,14 +96,14 @@ describe('StockCollaboratorController', () => {
         const collaborator = makeCollaborator();
         mockAddHandler.handle.mockResolvedValue(collaborator);
 
-        const req = {
+        req = {
           params: { stockId: '2' },
           body: { email: 'collab@test.com', role: 'EDITOR' },
           userID: 'owner@test.com',
           stockRole: 'OWNER',
-        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.addCollaborator(req, res);
+        await controller.addCollaborator(req as AddCollaboratorRequest & AuthorizedRequest, res);
 
         expect(mockAddHandler.handle).toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_CREATED);
@@ -125,14 +113,14 @@ describe('StockCollaboratorController', () => {
 
     describe('validation', () => {
       it('should return 400 when email is missing', async () => {
-        const req = {
+        req = {
           params: { stockId: '2' },
           body: { role: 'EDITOR' },
           userID: 'owner@test.com',
           stockRole: 'OWNER',
-        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.addCollaborator(req, res);
+        await controller.addCollaborator(req as AddCollaboratorRequest & AuthorizedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(400);
         expect(res.json).toHaveBeenCalledWith({ error: 'email and role are required' });
@@ -140,14 +128,14 @@ describe('StockCollaboratorController', () => {
       });
 
       it('should return 400 when role is missing', async () => {
-        const req = {
+        req = {
           params: { stockId: '2' },
           body: { email: 'collab@test.com' },
           userID: 'owner@test.com',
           stockRole: 'OWNER',
-        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.addCollaborator(req, res);
+        await controller.addCollaborator(req as AddCollaboratorRequest & AuthorizedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(400);
         expect(res.json).toHaveBeenCalledWith({ error: 'email and role are required' });
@@ -158,14 +146,14 @@ describe('StockCollaboratorController', () => {
       it('should return 403 when the handler throws a Forbidden error', async () => {
         mockAddHandler.handle.mockRejectedValue(new Error('Forbidden: insufficient role'));
 
-        const req = {
+        req = {
           params: { stockId: '2' },
           body: { email: 'collab@test.com', role: 'EDITOR' },
           userID: 'viewer@test.com',
           stockRole: 'VIEWER',
-        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.addCollaborator(req, res);
+        await controller.addCollaborator(req as AddCollaboratorRequest & AuthorizedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(403);
       });
@@ -173,14 +161,14 @@ describe('StockCollaboratorController', () => {
       it('should return 400 when the handler throws a not found error', async () => {
         mockAddHandler.handle.mockRejectedValue(new Error('User not found'));
 
-        const req = {
+        req = {
           params: { stockId: '2' },
           body: { email: 'unknown@test.com', role: 'EDITOR' },
           userID: 'owner@test.com',
           stockRole: 'OWNER',
-        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.addCollaborator(req, res);
+        await controller.addCollaborator(req as AddCollaboratorRequest & AuthorizedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(400);
       });
@@ -188,14 +176,14 @@ describe('StockCollaboratorController', () => {
       it('should return 500 for unexpected errors', async () => {
         mockAddHandler.handle.mockRejectedValue(new Error('Unexpected failure'));
 
-        const req = {
+        req = {
           params: { stockId: '2' },
           body: { email: 'collab@test.com', role: 'EDITOR' },
           userID: 'owner@test.com',
           stockRole: 'OWNER',
-        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.addCollaborator(req, res);
+        await controller.addCollaborator(req as AddCollaboratorRequest & AuthorizedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(500);
         expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
@@ -209,13 +197,16 @@ describe('StockCollaboratorController', () => {
         const updated = makeCollaborator({ role: 'VIEWER' });
         mockUpdateHandler.handle.mockResolvedValue(updated);
 
-        const req = {
+        req = {
           params: { stockId: '2', collaboratorId: '1' },
           body: { role: 'VIEWER' },
           stockRole: 'OWNER',
-        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.updateCollaboratorRole(req, res);
+        await controller.updateCollaboratorRole(
+          req as UpdateCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(mockUpdateHandler.handle).toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
@@ -225,13 +216,16 @@ describe('StockCollaboratorController', () => {
 
     describe('validation', () => {
       it('should return 400 when collaboratorId is not a number', async () => {
-        const req = {
+        req = {
           params: { stockId: '2', collaboratorId: 'abc' },
           body: { role: 'VIEWER' },
           stockRole: 'OWNER',
-        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.updateCollaboratorRole(req, res);
+        await controller.updateCollaboratorRole(
+          req as UpdateCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(400);
         expect(res.json).toHaveBeenCalledWith({ error: 'Invalid collaborator ID' });
@@ -239,13 +233,12 @@ describe('StockCollaboratorController', () => {
       });
 
       it('should return 400 when role is missing', async () => {
-        const req = {
-          params: { stockId: '2', collaboratorId: '1' },
-          body: {},
-          stockRole: 'OWNER',
-        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+        req = { params: { stockId: '2', collaboratorId: '1' }, body: {}, stockRole: 'OWNER' };
 
-        await controller.updateCollaboratorRole(req, res);
+        await controller.updateCollaboratorRole(
+          req as UpdateCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(400);
         expect(res.json).toHaveBeenCalledWith({ error: 'role is required' });
@@ -256,13 +249,16 @@ describe('StockCollaboratorController', () => {
       it('should return 403 when the handler throws a Forbidden error', async () => {
         mockUpdateHandler.handle.mockRejectedValue(new Error('Forbidden: insufficient role'));
 
-        const req = {
+        req = {
           params: { stockId: '2', collaboratorId: '1' },
           body: { role: 'VIEWER' },
           stockRole: 'EDITOR',
-        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.updateCollaboratorRole(req, res);
+        await controller.updateCollaboratorRole(
+          req as UpdateCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(403);
       });
@@ -270,13 +266,16 @@ describe('StockCollaboratorController', () => {
       it('should return 404 when the handler throws a not found error', async () => {
         mockUpdateHandler.handle.mockRejectedValue(new Error('Collaborator not found'));
 
-        const req = {
+        req = {
           params: { stockId: '2', collaboratorId: '99' },
           body: { role: 'VIEWER' },
           stockRole: 'OWNER',
-        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.updateCollaboratorRole(req, res);
+        await controller.updateCollaboratorRole(
+          req as UpdateCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(404);
       });
@@ -284,13 +283,16 @@ describe('StockCollaboratorController', () => {
       it('should return 500 for unexpected errors', async () => {
         mockUpdateHandler.handle.mockRejectedValue(new Error('Unexpected failure'));
 
-        const req = {
+        req = {
           params: { stockId: '2', collaboratorId: '1' },
           body: { role: 'VIEWER' },
           stockRole: 'OWNER',
-        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+        };
 
-        await controller.updateCollaboratorRole(req, res);
+        await controller.updateCollaboratorRole(
+          req as UpdateCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(500);
         expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
@@ -303,12 +305,12 @@ describe('StockCollaboratorController', () => {
       it('should return 204 on successful removal', async () => {
         mockRemoveHandler.handle.mockResolvedValue(undefined);
 
-        const req = {
-          params: { stockId: '2', collaboratorId: '1' },
-          stockRole: 'OWNER',
-        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+        req = { params: { stockId: '2', collaboratorId: '1' }, stockRole: 'OWNER' };
 
-        await controller.removeCollaborator(req, res);
+        await controller.removeCollaborator(
+          req as RemoveCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(mockRemoveHandler.handle).toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(204);
@@ -318,12 +320,12 @@ describe('StockCollaboratorController', () => {
 
     describe('validation', () => {
       it('should return 400 when collaboratorId is not a number', async () => {
-        const req = {
-          params: { stockId: '2', collaboratorId: 'abc' },
-          stockRole: 'OWNER',
-        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+        req = { params: { stockId: '2', collaboratorId: 'abc' }, stockRole: 'OWNER' };
 
-        await controller.removeCollaborator(req, res);
+        await controller.removeCollaborator(
+          req as RemoveCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(400);
         expect(res.json).toHaveBeenCalledWith({ error: 'Invalid collaborator ID' });
@@ -335,12 +337,12 @@ describe('StockCollaboratorController', () => {
       it('should return 403 when the handler throws a Forbidden error', async () => {
         mockRemoveHandler.handle.mockRejectedValue(new Error('Forbidden: insufficient role'));
 
-        const req = {
-          params: { stockId: '2', collaboratorId: '1' },
-          stockRole: 'EDITOR',
-        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+        req = { params: { stockId: '2', collaboratorId: '1' }, stockRole: 'EDITOR' };
 
-        await controller.removeCollaborator(req, res);
+        await controller.removeCollaborator(
+          req as RemoveCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(403);
       });
@@ -348,12 +350,12 @@ describe('StockCollaboratorController', () => {
       it('should return 404 when the handler throws a not found error', async () => {
         mockRemoveHandler.handle.mockRejectedValue(new Error('Collaborator not found'));
 
-        const req = {
-          params: { stockId: '2', collaboratorId: '99' },
-          stockRole: 'OWNER',
-        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+        req = { params: { stockId: '2', collaboratorId: '99' }, stockRole: 'OWNER' };
 
-        await controller.removeCollaborator(req, res);
+        await controller.removeCollaborator(
+          req as RemoveCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(404);
       });
@@ -361,12 +363,12 @@ describe('StockCollaboratorController', () => {
       it('should return 500 for unexpected errors', async () => {
         mockRemoveHandler.handle.mockRejectedValue(new Error('Unexpected failure'));
 
-        const req = {
-          params: { stockId: '2', collaboratorId: '1' },
-          stockRole: 'OWNER',
-        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+        req = { params: { stockId: '2', collaboratorId: '1' }, stockRole: 'OWNER' };
 
-        await controller.removeCollaborator(req, res);
+        await controller.removeCollaborator(
+          req as RemoveCollaboratorRequest & AuthorizedRequest,
+          res
+        );
 
         expect(res.status).toHaveBeenCalledWith(500);
         expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });

--- a/tests/api/controllers/StockCollaboratorController.test.ts
+++ b/tests/api/controllers/StockCollaboratorController.test.ts
@@ -1,0 +1,376 @@
+import { Response } from 'express';
+import { StockCollaboratorController } from '@api/controllers/StockCollaboratorController';
+import {
+  ICollaboratorRepository,
+  CollaboratorData,
+} from '@domain/authorization/collaboration/repositories/ICollaboratorRepository';
+import { AddCollaboratorCommandHandler } from '@domain/authorization/collaboration/command-handlers/AddCollaboratorCommandHandler';
+import { UpdateCollaboratorRoleCommandHandler } from '@domain/authorization/collaboration/command-handlers/UpdateCollaboratorRoleCommandHandler';
+import { RemoveCollaboratorCommandHandler } from '@domain/authorization/collaboration/command-handlers/RemoveCollaboratorCommandHandler';
+import { HTTP_CODE_CREATED, HTTP_CODE_OK } from '@utils/httpCodes';
+import { AuthorizedRequest } from '@authorization/authorizeMiddleware';
+import {
+  AddCollaboratorRequest,
+  UpdateCollaboratorRequest,
+  RemoveCollaboratorRequest,
+} from '@api/types/StockRequestTypes';
+
+jest.mock('@utils/logger', () => ({
+  rootController: { getChildCategory: () => ({ info: jest.fn(), error: jest.fn() }) },
+}));
+
+const makeCollaborator = (overrides: Partial<CollaboratorData> = {}): CollaboratorData => ({
+  id: 1,
+  stockId: 2,
+  userId: 10,
+  userEmail: 'collab@test.com',
+  role: 'EDITOR',
+  grantedAt: new Date('2026-04-10'),
+  grantedBy: 5,
+  ...overrides,
+});
+
+describe('StockCollaboratorController', () => {
+  let controller: StockCollaboratorController;
+  let res: jest.Mocked<Response>;
+  let mockRepository: jest.Mocked<ICollaboratorRepository>;
+  let mockAddHandler: jest.Mocked<Pick<AddCollaboratorCommandHandler, 'handle'>>;
+  let mockUpdateHandler: jest.Mocked<Pick<UpdateCollaboratorRoleCommandHandler, 'handle'>>;
+  let mockRemoveHandler: jest.Mocked<Pick<RemoveCollaboratorCommandHandler, 'handle'>>;
+
+  beforeEach(() => {
+    mockRepository = {
+      findByStockId: jest.fn(),
+      findById: jest.fn(),
+      findUserByEmail: jest.fn(),
+      isCollaborator: jest.fn(),
+      add: jest.fn(),
+      updateRole: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    mockAddHandler = { handle: jest.fn() };
+    mockUpdateHandler = { handle: jest.fn() };
+    mockRemoveHandler = { handle: jest.fn() };
+
+    controller = new StockCollaboratorController(
+      mockRepository,
+      mockAddHandler as unknown as AddCollaboratorCommandHandler,
+      mockUpdateHandler as unknown as UpdateCollaboratorRoleCommandHandler,
+      mockRemoveHandler as unknown as RemoveCollaboratorCommandHandler
+    );
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      send: jest.fn(),
+    } as unknown as jest.Mocked<Response>;
+
+    jest.clearAllMocks();
+  });
+
+  describe('listCollaborators', () => {
+    describe('nominal case', () => {
+      it('should return 200 with the collaborators list', async () => {
+        const collaborators = [
+          makeCollaborator(),
+          makeCollaborator({ id: 2, userEmail: 'other@test.com' }),
+        ];
+        mockRepository.findByStockId.mockResolvedValue(collaborators);
+
+        const req = { params: { stockId: '2' } } as unknown as AuthorizedRequest;
+
+        await controller.listCollaborators(req, res);
+
+        expect(mockRepository.findByStockId).toHaveBeenCalledWith(2);
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(collaborators);
+      });
+    });
+
+    describe('error case', () => {
+      it('should return 500 when the repository throws', async () => {
+        mockRepository.findByStockId.mockRejectedValue(new Error('DB error'));
+
+        const req = { params: { stockId: '2' } } as unknown as AuthorizedRequest;
+
+        await controller.listCollaborators(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      });
+    });
+  });
+
+  describe('addCollaborator', () => {
+    describe('nominal case', () => {
+      it('should return 201 with the added collaborator', async () => {
+        const collaborator = makeCollaborator();
+        mockAddHandler.handle.mockResolvedValue(collaborator);
+
+        const req = {
+          params: { stockId: '2' },
+          body: { email: 'collab@test.com', role: 'EDITOR' },
+          userID: 'owner@test.com',
+          stockRole: 'OWNER',
+        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+
+        await controller.addCollaborator(req, res);
+
+        expect(mockAddHandler.handle).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_CREATED);
+        expect(res.json).toHaveBeenCalledWith(collaborator);
+      });
+    });
+
+    describe('validation', () => {
+      it('should return 400 when email is missing', async () => {
+        const req = {
+          params: { stockId: '2' },
+          body: { role: 'EDITOR' },
+          userID: 'owner@test.com',
+          stockRole: 'OWNER',
+        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+
+        await controller.addCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'email and role are required' });
+        expect(mockAddHandler.handle).not.toHaveBeenCalled();
+      });
+
+      it('should return 400 when role is missing', async () => {
+        const req = {
+          params: { stockId: '2' },
+          body: { email: 'collab@test.com' },
+          userID: 'owner@test.com',
+          stockRole: 'OWNER',
+        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+
+        await controller.addCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'email and role are required' });
+      });
+    });
+
+    describe('error cases', () => {
+      it('should return 403 when the handler throws a Forbidden error', async () => {
+        mockAddHandler.handle.mockRejectedValue(new Error('Forbidden: insufficient role'));
+
+        const req = {
+          params: { stockId: '2' },
+          body: { email: 'collab@test.com', role: 'EDITOR' },
+          userID: 'viewer@test.com',
+          stockRole: 'VIEWER',
+        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+
+        await controller.addCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+      });
+
+      it('should return 400 when the handler throws a not found error', async () => {
+        mockAddHandler.handle.mockRejectedValue(new Error('User not found'));
+
+        const req = {
+          params: { stockId: '2' },
+          body: { email: 'unknown@test.com', role: 'EDITOR' },
+          userID: 'owner@test.com',
+          stockRole: 'OWNER',
+        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+
+        await controller.addCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+      });
+
+      it('should return 500 for unexpected errors', async () => {
+        mockAddHandler.handle.mockRejectedValue(new Error('Unexpected failure'));
+
+        const req = {
+          params: { stockId: '2' },
+          body: { email: 'collab@test.com', role: 'EDITOR' },
+          userID: 'owner@test.com',
+          stockRole: 'OWNER',
+        } as unknown as AddCollaboratorRequest & AuthorizedRequest;
+
+        await controller.addCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      });
+    });
+  });
+
+  describe('updateCollaboratorRole', () => {
+    describe('nominal case', () => {
+      it('should return 200 with the updated collaborator', async () => {
+        const updated = makeCollaborator({ role: 'VIEWER' });
+        mockUpdateHandler.handle.mockResolvedValue(updated);
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          body: { role: 'VIEWER' },
+          stockRole: 'OWNER',
+        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+
+        await controller.updateCollaboratorRole(req, res);
+
+        expect(mockUpdateHandler.handle).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(updated);
+      });
+    });
+
+    describe('validation', () => {
+      it('should return 400 when collaboratorId is not a number', async () => {
+        const req = {
+          params: { stockId: '2', collaboratorId: 'abc' },
+          body: { role: 'VIEWER' },
+          stockRole: 'OWNER',
+        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+
+        await controller.updateCollaboratorRole(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Invalid collaborator ID' });
+        expect(mockUpdateHandler.handle).not.toHaveBeenCalled();
+      });
+
+      it('should return 400 when role is missing', async () => {
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          body: {},
+          stockRole: 'OWNER',
+        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+
+        await controller.updateCollaboratorRole(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'role is required' });
+      });
+    });
+
+    describe('error cases', () => {
+      it('should return 403 when the handler throws a Forbidden error', async () => {
+        mockUpdateHandler.handle.mockRejectedValue(new Error('Forbidden: insufficient role'));
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          body: { role: 'VIEWER' },
+          stockRole: 'EDITOR',
+        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+
+        await controller.updateCollaboratorRole(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+      });
+
+      it('should return 404 when the handler throws a not found error', async () => {
+        mockUpdateHandler.handle.mockRejectedValue(new Error('Collaborator not found'));
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '99' },
+          body: { role: 'VIEWER' },
+          stockRole: 'OWNER',
+        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+
+        await controller.updateCollaboratorRole(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+      });
+
+      it('should return 500 for unexpected errors', async () => {
+        mockUpdateHandler.handle.mockRejectedValue(new Error('Unexpected failure'));
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          body: { role: 'VIEWER' },
+          stockRole: 'OWNER',
+        } as unknown as UpdateCollaboratorRequest & AuthorizedRequest;
+
+        await controller.updateCollaboratorRole(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      });
+    });
+  });
+
+  describe('removeCollaborator', () => {
+    describe('nominal case', () => {
+      it('should return 204 on successful removal', async () => {
+        mockRemoveHandler.handle.mockResolvedValue(undefined);
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          stockRole: 'OWNER',
+        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+
+        await controller.removeCollaborator(req, res);
+
+        expect(mockRemoveHandler.handle).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(204);
+        expect(res.send).toHaveBeenCalled();
+      });
+    });
+
+    describe('validation', () => {
+      it('should return 400 when collaboratorId is not a number', async () => {
+        const req = {
+          params: { stockId: '2', collaboratorId: 'abc' },
+          stockRole: 'OWNER',
+        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+
+        await controller.removeCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Invalid collaborator ID' });
+        expect(mockRemoveHandler.handle).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('error cases', () => {
+      it('should return 403 when the handler throws a Forbidden error', async () => {
+        mockRemoveHandler.handle.mockRejectedValue(new Error('Forbidden: insufficient role'));
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          stockRole: 'EDITOR',
+        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+
+        await controller.removeCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+      });
+
+      it('should return 404 when the handler throws a not found error', async () => {
+        mockRemoveHandler.handle.mockRejectedValue(new Error('Collaborator not found'));
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '99' },
+          stockRole: 'OWNER',
+        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+
+        await controller.removeCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+      });
+
+      it('should return 500 for unexpected errors', async () => {
+        mockRemoveHandler.handle.mockRejectedValue(new Error('Unexpected failure'));
+
+        const req = {
+          params: { stockId: '2', collaboratorId: '1' },
+          stockRole: 'OWNER',
+        } as unknown as RemoveCollaboratorRequest & AuthorizedRequest;
+
+        await controller.removeCollaborator(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      });
+    });
+  });
+});

--- a/tests/api/controllers/StockContributionController.test.ts
+++ b/tests/api/controllers/StockContributionController.test.ts
@@ -1,0 +1,224 @@
+import { Request, Response } from 'express';
+import { StockContributionController } from '@api/controllers/StockContributionController';
+import { sendError } from '@api/errors';
+import { CreateContributionCommandHandler } from '@domain/stock-management/manipulation/use-cases/CreateContributionCommandHandler';
+import { ReviewContributionCommandHandler } from '@domain/stock-management/manipulation/use-cases/ReviewContributionCommandHandler';
+import { IContributionRepository } from '@domain/stock-management/manipulation/repositories/IContributionRepository';
+import { UserService } from '@domain/user/services/UserService';
+import { ItemContribution } from '@domain/stock-management/common/entities/ItemContribution';
+import { HTTP_CODE_CREATED, HTTP_CODE_OK } from '@utils/httpCodes';
+import { CreateContributionRequest, ReviewContributionRequest } from '@api/types/StockRequestTypes';
+import { AuthenticatedRequest } from '@api/types/AuthenticatedRequest';
+
+jest.mock('@api/errors', () => ({ sendError: jest.fn() }));
+jest.mock('@utils/cloudLogger', () => ({ rootException: jest.fn() }));
+jest.mock('@utils/logger', () => ({
+  rootMain: { info: jest.fn(), error: jest.fn() },
+}));
+
+const makeContribution = (overrides: Partial<ItemContribution> = {}): ItemContribution =>
+  ({
+    id: 1,
+    itemId: 10,
+    stockId: 2,
+    contributedBy: 42,
+    suggestedQuantity: 5,
+    status: { value: 'PENDING' },
+    reviewedBy: null,
+    reviewedAt: null,
+    createdAt: new Date('2026-04-10'),
+    ...overrides,
+  }) as unknown as ItemContribution;
+
+describe('StockContributionController', () => {
+  let controller: StockContributionController;
+  let req: Partial<Request> & { userID?: string };
+  let res: jest.Mocked<Response>;
+  let mockCreateHandler: jest.Mocked<Pick<CreateContributionCommandHandler, 'handle'>>;
+  let mockReviewHandler: jest.Mocked<Pick<ReviewContributionCommandHandler, 'handle'>>;
+  let mockContributionRepository: jest.Mocked<IContributionRepository>;
+  let mockUserService: jest.Mocked<Pick<UserService, 'convertOIDtoUserID' | 'addUser'>>;
+
+  beforeEach(() => {
+    mockCreateHandler = { handle: jest.fn() };
+    mockReviewHandler = { handle: jest.fn() };
+
+    mockContributionRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findPendingByStockId: jest.fn(),
+      update: jest.fn(),
+      countPendingForUser: jest.fn(),
+    };
+
+    mockUserService = {
+      convertOIDtoUserID: jest.fn(),
+      addUser: jest.fn(),
+    };
+
+    controller = new StockContributionController(
+      mockCreateHandler as unknown as CreateContributionCommandHandler,
+      mockReviewHandler as unknown as ReviewContributionCommandHandler,
+      mockContributionRepository,
+      mockUserService as unknown as UserService
+    );
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      send: jest.fn(),
+    } as unknown as jest.Mocked<Response>;
+
+    jest.clearAllMocks();
+  });
+
+  describe('createContribution', () => {
+    describe('nominal case', () => {
+      it('should return 201 with the created contribution', async () => {
+        const contribution = makeContribution();
+        mockUserService.convertOIDtoUserID.mockResolvedValue({ value: 42, empty: false } as never);
+        mockCreateHandler.handle.mockResolvedValue(contribution);
+
+        req = {
+          userID: 'user@test.com',
+          params: { stockId: '2', itemId: '10' },
+          body: { suggestedQuantity: 5 },
+        };
+
+        await controller.createContribution(req as unknown as CreateContributionRequest, res);
+
+        expect(mockUserService.convertOIDtoUserID).toHaveBeenCalledWith('user@test.com');
+        expect(mockCreateHandler.handle).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_CREATED);
+        expect(res.json).toHaveBeenCalledWith(contribution);
+      });
+    });
+
+    describe('missing OID', () => {
+      it('should return 401 when userID is absent', async () => {
+        req = {
+          params: { stockId: '2', itemId: '10' },
+          body: { suggestedQuantity: 5 },
+        };
+
+        await controller.createContribution(req as unknown as CreateContributionRequest, res);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({ error: 'User not authenticated' });
+        expect(mockCreateHandler.handle).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('error case', () => {
+      it('should call sendError when the handler throws', async () => {
+        const error = new Error('DB error');
+        mockUserService.convertOIDtoUserID.mockResolvedValue({ value: 42, empty: false } as never);
+        mockCreateHandler.handle.mockRejectedValue(error);
+
+        req = {
+          userID: 'user@test.com',
+          params: { stockId: '2', itemId: '10' },
+          body: { suggestedQuantity: 5 },
+        };
+
+        await controller.createContribution(req as unknown as CreateContributionRequest, res);
+
+        expect(sendError).toHaveBeenCalledWith(res, error);
+      });
+    });
+  });
+
+  describe('getPendingCount', () => {
+    describe('nominal case', () => {
+      it('should return 200 with the pending count', async () => {
+        mockUserService.convertOIDtoUserID.mockResolvedValue({ value: 42, empty: false } as never);
+        mockContributionRepository.countPendingForUser.mockResolvedValue(3);
+
+        req = { userID: 'user@test.com' };
+
+        await controller.getPendingCount(req as unknown as AuthenticatedRequest, res);
+
+        expect(mockContributionRepository.countPendingForUser).toHaveBeenCalledWith(42);
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith({ count: 3 });
+      });
+    });
+
+    describe('missing OID', () => {
+      it('should return 401 when userID is absent', async () => {
+        req = {};
+
+        await controller.getPendingCount(req as unknown as AuthenticatedRequest, res);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({ error: 'User not authenticated' });
+        expect(mockContributionRepository.countPendingForUser).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('listContributions', () => {
+    describe('nominal case', () => {
+      it('should return 200 with the contributions list', async () => {
+        const contributions = [makeContribution(), makeContribution({ id: 2 })];
+        mockContributionRepository.findPendingByStockId.mockResolvedValue(contributions);
+
+        req = { userID: 'user@test.com', params: { stockId: '2' } };
+
+        await controller.listContributions(req as unknown as AuthenticatedRequest, res);
+
+        expect(mockContributionRepository.findPendingByStockId).toHaveBeenCalledWith(2);
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(contributions);
+      });
+    });
+
+    describe('missing OID', () => {
+      it('should return 401 when userID is absent', async () => {
+        req = { params: { stockId: '2' } };
+
+        await controller.listContributions(req as unknown as AuthenticatedRequest, res);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({ error: 'User not authenticated' });
+        expect(mockContributionRepository.findPendingByStockId).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('reviewContribution', () => {
+    describe('nominal case', () => {
+      it('should return 200 with the reviewed contribution', async () => {
+        const contribution = makeContribution({ status: { value: 'APPROVED' } as never });
+        mockUserService.convertOIDtoUserID.mockResolvedValue({ value: 42, empty: false } as never);
+        mockReviewHandler.handle.mockResolvedValue(contribution);
+
+        req = {
+          userID: 'user@test.com',
+          params: { stockId: '2', contributionId: '1' },
+          body: { action: 'approve' },
+        };
+
+        await controller.reviewContribution(req as unknown as ReviewContributionRequest, res);
+
+        expect(mockReviewHandler.handle).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(contribution);
+      });
+    });
+
+    describe('missing OID', () => {
+      it('should return 401 when userID is absent', async () => {
+        req = {
+          params: { stockId: '2', contributionId: '1' },
+          body: { action: 'approve' },
+        };
+
+        await controller.reviewContribution(req as unknown as ReviewContributionRequest, res);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(mockReviewHandler.handle).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/tests/api/controllers/StockContributionController.test.ts
+++ b/tests/api/controllers/StockContributionController.test.ts
@@ -1,14 +1,15 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { StockContributionController } from '@api/controllers/StockContributionController';
 import { sendError } from '@api/errors';
 import { CreateContributionCommandHandler } from '@domain/stock-management/manipulation/use-cases/CreateContributionCommandHandler';
 import { ReviewContributionCommandHandler } from '@domain/stock-management/manipulation/use-cases/ReviewContributionCommandHandler';
 import { IContributionRepository } from '@domain/stock-management/manipulation/repositories/IContributionRepository';
 import { UserService } from '@domain/user/services/UserService';
-import { ItemContribution } from '@domain/stock-management/common/entities/ItemContribution';
 import { HTTP_CODE_CREATED, HTTP_CODE_OK } from '@utils/httpCodes';
-import { CreateContributionRequest, ReviewContributionRequest } from '@api/types/StockRequestTypes';
 import { AuthenticatedRequest } from '@api/types/AuthenticatedRequest';
+import { CreateContributionRequest, ReviewContributionRequest } from '@api/types/StockRequestTypes';
+import { ContributionStatus } from '@domain/stock-management/common/value-objects/ContributionStatus';
+import { makeContribution } from '../../fixtures/contribution.fixtures';
 
 jest.mock('@api/errors', () => ({ sendError: jest.fn() }));
 jest.mock('@utils/cloudLogger', () => ({ rootException: jest.fn() }));
@@ -16,23 +17,9 @@ jest.mock('@utils/logger', () => ({
   rootMain: { info: jest.fn(), error: jest.fn() },
 }));
 
-const makeContribution = (overrides: Partial<ItemContribution> = {}): ItemContribution =>
-  ({
-    id: 1,
-    itemId: 10,
-    stockId: 2,
-    contributedBy: 42,
-    suggestedQuantity: 5,
-    status: { value: 'PENDING' },
-    reviewedBy: null,
-    reviewedAt: null,
-    createdAt: new Date('2026-04-10'),
-    ...overrides,
-  }) as unknown as ItemContribution;
-
 describe('StockContributionController', () => {
   let controller: StockContributionController;
-  let req: Partial<Request> & { userID?: string };
+  let req: Partial<AuthenticatedRequest>;
   let res: jest.Mocked<Response>;
   let mockCreateHandler: jest.Mocked<Pick<CreateContributionCommandHandler, 'handle'>>;
   let mockReviewHandler: jest.Mocked<Pick<ReviewContributionCommandHandler, 'handle'>>;
@@ -85,7 +72,7 @@ describe('StockContributionController', () => {
           body: { suggestedQuantity: 5 },
         };
 
-        await controller.createContribution(req as unknown as CreateContributionRequest, res);
+        await controller.createContribution(req as CreateContributionRequest, res);
 
         expect(mockUserService.convertOIDtoUserID).toHaveBeenCalledWith('user@test.com');
         expect(mockCreateHandler.handle).toHaveBeenCalled();
@@ -96,12 +83,9 @@ describe('StockContributionController', () => {
 
     describe('missing OID', () => {
       it('should return 401 when userID is absent', async () => {
-        req = {
-          params: { stockId: '2', itemId: '10' },
-          body: { suggestedQuantity: 5 },
-        };
+        req = { params: { stockId: '2', itemId: '10' }, body: { suggestedQuantity: 5 } };
 
-        await controller.createContribution(req as unknown as CreateContributionRequest, res);
+        await controller.createContribution(req as CreateContributionRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(401);
         expect(res.json).toHaveBeenCalledWith({ error: 'User not authenticated' });
@@ -121,7 +105,7 @@ describe('StockContributionController', () => {
           body: { suggestedQuantity: 5 },
         };
 
-        await controller.createContribution(req as unknown as CreateContributionRequest, res);
+        await controller.createContribution(req as CreateContributionRequest, res);
 
         expect(sendError).toHaveBeenCalledWith(res, error);
       });
@@ -136,7 +120,7 @@ describe('StockContributionController', () => {
 
         req = { userID: 'user@test.com' };
 
-        await controller.getPendingCount(req as unknown as AuthenticatedRequest, res);
+        await controller.getPendingCount(req as AuthenticatedRequest, res);
 
         expect(mockContributionRepository.countPendingForUser).toHaveBeenCalledWith(42);
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
@@ -148,7 +132,7 @@ describe('StockContributionController', () => {
       it('should return 401 when userID is absent', async () => {
         req = {};
 
-        await controller.getPendingCount(req as unknown as AuthenticatedRequest, res);
+        await controller.getPendingCount(req as AuthenticatedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(401);
         expect(res.json).toHaveBeenCalledWith({ error: 'User not authenticated' });
@@ -165,7 +149,7 @@ describe('StockContributionController', () => {
 
         req = { userID: 'user@test.com', params: { stockId: '2' } };
 
-        await controller.listContributions(req as unknown as AuthenticatedRequest, res);
+        await controller.listContributions(req as AuthenticatedRequest, res);
 
         expect(mockContributionRepository.findPendingByStockId).toHaveBeenCalledWith(2);
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
@@ -177,7 +161,7 @@ describe('StockContributionController', () => {
       it('should return 401 when userID is absent', async () => {
         req = { params: { stockId: '2' } };
 
-        await controller.listContributions(req as unknown as AuthenticatedRequest, res);
+        await controller.listContributions(req as AuthenticatedRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(401);
         expect(res.json).toHaveBeenCalledWith({ error: 'User not authenticated' });
@@ -189,7 +173,7 @@ describe('StockContributionController', () => {
   describe('reviewContribution', () => {
     describe('nominal case', () => {
       it('should return 200 with the reviewed contribution', async () => {
-        const contribution = makeContribution({ status: { value: 'APPROVED' } as never });
+        const contribution = makeContribution({ status: new ContributionStatus('APPROVED') });
         mockUserService.convertOIDtoUserID.mockResolvedValue({ value: 42, empty: false } as never);
         mockReviewHandler.handle.mockResolvedValue(contribution);
 
@@ -199,7 +183,7 @@ describe('StockContributionController', () => {
           body: { action: 'approve' },
         };
 
-        await controller.reviewContribution(req as unknown as ReviewContributionRequest, res);
+        await controller.reviewContribution(req as ReviewContributionRequest, res);
 
         expect(mockReviewHandler.handle).toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
@@ -209,12 +193,9 @@ describe('StockContributionController', () => {
 
     describe('missing OID', () => {
       it('should return 401 when userID is absent', async () => {
-        req = {
-          params: { stockId: '2', contributionId: '1' },
-          body: { action: 'approve' },
-        };
+        req = { params: { stockId: '2', contributionId: '1' }, body: { action: 'approve' } };
 
-        await controller.reviewContribution(req as unknown as ReviewContributionRequest, res);
+        await controller.reviewContribution(req as ReviewContributionRequest, res);
 
         expect(res.status).toHaveBeenCalledWith(401);
         expect(mockReviewHandler.handle).not.toHaveBeenCalled();

--- a/tests/fixtures/collaborator.fixtures.ts
+++ b/tests/fixtures/collaborator.fixtures.ts
@@ -1,0 +1,12 @@
+import { CollaboratorData } from '@domain/authorization/collaboration/repositories/ICollaboratorRepository';
+
+export const makeCollaborator = (overrides: Partial<CollaboratorData> = {}): CollaboratorData => ({
+  id: 1,
+  stockId: 2,
+  userId: 10,
+  userEmail: 'collab@test.com',
+  role: 'EDITOR',
+  grantedAt: new Date('2026-04-10'),
+  grantedBy: 5,
+  ...overrides,
+});

--- a/tests/fixtures/contribution.fixtures.ts
+++ b/tests/fixtures/contribution.fixtures.ts
@@ -1,0 +1,24 @@
+import { ItemContribution } from '@domain/stock-management/common/entities/ItemContribution';
+import { ContributionStatus } from '@domain/stock-management/common/value-objects/ContributionStatus';
+
+type ContributionParams = {
+  id?: number;
+  itemId?: number;
+  stockId?: number;
+  contributedBy?: number;
+  suggestedQuantity?: number;
+  status?: ContributionStatus;
+};
+
+export const makeContribution = (params: ContributionParams = {}): ItemContribution =>
+  new ItemContribution(
+    params.id ?? 1,
+    params.itemId ?? 10,
+    params.stockId ?? 2,
+    params.contributedBy ?? 42,
+    params.suggestedQuantity ?? 5,
+    params.status ?? ContributionStatus.pending(),
+    null,
+    null,
+    new Date('2026-04-10')
+  );


### PR DESCRIPTION
## Couches DDD impactées

- `tests/api/controllers/` — couche API (controllers)

## Changements

Ajout de tests unitaires pour les deux derniers controllers sans couverture :

- **`StockContributionController`** — 12 tests
  - `createContribution` : cas nominal (201), OID absent (401), erreur handler
  - `getPendingCount` : cas nominal (200), OID absent (401)
  - `listContributions` : cas nominal (200), OID absent (401)
  - `reviewContribution` : cas nominal (200), OID absent (401)

- **`StockCollaboratorController`** — 16 tests
  - `listCollaborators` : cas nominal (200), erreur repo (500)
  - `addCollaborator` : nominal (201), validation email/role (400), Forbidden (403), not found (400), inattendu (500)
  - `updateCollaboratorRole` : nominal (200), ID invalide (400), role absent (400), Forbidden (403), not found (404), inattendu (500)
  - `removeCollaborator` : nominal (204), ID invalide (400), Forbidden (403), not found (404), inattendu (500)

Total suite : 310 tests (28 nouveaux).

## Test plan

- [x] `npm run test:unit` — 310 tests, 35 suites, tous verts
- [x] Hooks pre-push passés

Closes #204