### PR TITLE
chore(ci): add coverageThreshold to jest.ci.config — closes #208

### DIFF
--- a/jest.ci.config.js
+++ b/jest.ci.config.js
@@ -41,4 +41,12 @@ module.exports = {
     '<rootDir>/src/api/controllers/**/*.ts',
     '!<rootDir>/src/**/*.d.ts',
   ],
+  coverageThreshold: {
+    global: {
+      statements: 85,
+      branches: 65,
+      functions: 90,
+      lines: 85,
+    },
+  },
 };


### PR DESCRIPTION
## Couches DDD impactées

- CI uniquement (`jest.ci.config.js`)

## Changements

Ajout de seuils de couverture dans `jest.ci.config.js` basés sur le rapport du 2026-04-14 :

| Métrique   | Seuil | Valeur actuelle |
|------------|-------|-----------------|
| Statements | 85%   | 85.75%          |
| Branches   | 65%   | 68.75%          |
| Functions  | 90%   | 90.47%          |
| Lines      | 85%   | 86.21%          |

Les seuils sont fixés légèrement en dessous des valeurs mesurées pour absorber les fluctuations sans bloquer la CI. L'amélioration de la branch coverage (actuellement faible sur les manipulation handlers) est trackée dans #209.

## Test plan

- [x] `npm run test:unit` — 310 tests verts
- [x] Hooks pre-push passés

Closes #208