### PR TITLE
perf(ci): move e2e tests to manual trigger and weekly schedule — closes #211

### DIFF
--- a/.github/workflows/main_stockhub-back.yml
+++ b/.github/workflows/main_stockhub-back.yml
@@ -10,6 +10,8 @@ on:
     branches: ['*']
     types: [opened, synchronize]
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Lundi 6h UTC — détection régressions e2e sur main
 
 jobs:
   # CI Job - s'exécute sur toutes les branches
@@ -41,10 +43,10 @@ jobs:
       - name: Check outdated dependencies (informational)
         run: npm outdated || true
 
-  # E2E Tests - s'exécute sur PR vers main et workflow_dispatch
+  # E2E Tests - déclenchement manuel ou cron hebdomadaire (lundi 6h UTC)
   e2e-tests:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs:
       - continuous-integration
     services:


### PR DESCRIPTION
## Couches DDD impactées

- CI uniquement (`.github/workflows/main_stockhub-back.yml`)

## Changements

Les e2e bloquaient chaque PR vers `main` (~10-15min). Pattern adopté en entreprise : tests unitaires sur chaque PR (rapides, bloquants), e2e déclenchés manuellement ou en cron.

**Avant :** e2e sur toute PR vers main + `workflow_dispatch`
**Après :** e2e sur `workflow_dispatch` (manuel) + cron lundi 6h UTC

```yaml
# Trigger ajouté
schedule:
  - cron: '0 6 * * 1'  # Lundi 6h UTC

# Condition e2e modifiée
if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
```

**Impact attendu sur les PRs :** ~10-15min → ~2min

## Test plan

- [x] CI sur cette PR passe en ~2min (sans e2e)
- [x] Les e2e restent déclenchables manuellement via "Run workflow" dans GitHub Actions
- [x] Cron configuré pour détection hebdomadaire des régressions

Closes #211