### PR TITLE
chore(ci): switch security audit to --audit-level=high — closes #215

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -29,8 +29,7 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        run: npm audit --audit-level=critical
-        #        run: npm audit --audit-level=high
+        run: npm audit --audit-level=high
         continue-on-error: false
 
       - name: Security audit summary


### PR DESCRIPTION
## Couches DDD impactées

- CI uniquement (`.github/workflows/security-audit.yml`)

## Changements

`--audit-level=critical` → `--audit-level=high`

Possible maintenant car les CVEs high ont été corrigées (`npm audit fix` en avril 2026) :
- axios SSRF critical → 1.15.0 ✅
- defu prototype pollution high → 6.1.7 ✅
- lodash code injection high → 4.18.1 ✅

Seule vulnérabilité restante : `follow-redirects` moderate (non bloquante).

## Test plan

- [x] `npm audit --audit-level=high` passe en local (1 moderate non bloquante)

Closes #215