### PR TITLE
chore(infra): update render.yaml nodeVersion to 22 — closes #217

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: stockhub-back-staging
     runtime: node
     region: frankfurt
-    nodeVersion: 20
+    nodeVersion: 22
     buildCommand: npm ci && npm run build
     startCommand: node dist/index.js
     healthCheckPath: /api-docs.json


### PR DESCRIPTION
## Changements

`nodeVersion: 20` → `nodeVersion: 22` dans `render.yaml`

Aligne le staging Render avec la CI (Node 22.x) et la prod Azure (Node 22.x).

Le `.env.example` existant est déjà complet et conforme.

Closes #217