### PR TITLE
feat(prediction): return 400 when itemId is not a valid number — closes #195

### DIFF
--- a/src/api/controllers/StockPredictionController.ts
+++ b/src/api/controllers/StockPredictionController.ts
@@ -19,6 +19,10 @@ export class StockPredictionController {
   public async getItemHistory(req: express.Request, res: express.Response): Promise<void> {
     try {
       const itemId = Number(req.params.itemId);
+      if (isNaN(itemId)) {
+        res.status(400).json({ error: 'Invalid itemId' });
+        return;
+      }
       const days = Number(req.query['days'] ?? 90);
 
       const history = await this.historyRepository.getHistory(itemId, days);
@@ -35,6 +39,10 @@ export class StockPredictionController {
   public async getItemPrediction(req: express.Request, res: express.Response): Promise<void> {
     try {
       const itemId = Number(req.params.itemId);
+      if (isNaN(itemId)) {
+        res.status(400).json({ error: 'Invalid itemId' });
+        return;
+      }
       const currentQuantity = Number(req.query['quantity'] ?? 0);
       const minimumStock = Number(req.query['minimumStock'] ?? 1);
 

--- a/tests/api/controllers/StockPredictionController.test.ts
+++ b/tests/api/controllers/StockPredictionController.test.ts
@@ -120,6 +120,18 @@ describe('StockPredictionController', () => {
       });
     });
 
+    describe('invalid itemId', () => {
+      it('should return 400 when itemId is not a number', async () => {
+        req = { params: { itemId: 'abc' }, query: {} };
+
+        await controller.getItemHistory(req as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Invalid itemId' });
+        expect(mockHistoryRepository.getHistory).not.toHaveBeenCalled();
+      });
+    });
+
     describe('error case', () => {
       it('should call sendError when the repository throws', async () => {
         const error = new Error('DB connection failed');
@@ -179,6 +191,18 @@ describe('StockPredictionController', () => {
         await controller.getItemPrediction(req as Request, res);
 
         expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(3, 0, 1);
+      });
+    });
+
+    describe('invalid itemId', () => {
+      it('should return 400 when itemId is not a number', async () => {
+        req = { params: { itemId: 'abc' }, query: {} };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Invalid itemId' });
+        expect(mockPredictionRepository.getLatest).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Couches DDD impactées

- `src/api/controllers/` — StockPredictionController
- `tests/api/controllers/` — StockPredictionController.test.ts

## Changements

Ajout d'une validation manuelle sur `itemId` dans `getItemHistory` et `getItemPrediction`.
Cohérent avec le pattern existant dans `StockCollaboratorController` (`isNaN` check).

Note : la validation centralisée via Zod est trackée dans #219.

## Test plan

- [x] `getItemHistory('abc')` → 400 `{ error: 'Invalid itemId' }`
- [x] `getItemPrediction('abc')` → 400 `{ error: 'Invalid itemId' }`
- [x] 10 tests, tous verts

Closes #195