### PR TITLE
feat(prediction): return 404 when history is insufficient — closes #196

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -549,7 +549,7 @@ paths:
         Retourne la dernière prédiction calculée pour un item (cache). Si aucune prédiction n'existe, en calcule une à la volée.
 
         Les prédictions sont recalculées automatiquement chaque matin (cron job).
-        Si l'historique est insuffisant (< 7 jours de consommation), `simulatedFallback=true` est retourné.
+        Si l'historique est insuffisant (< 7 jours de consommation), retourne 404.
       tags:
         - Stock Prediction (READ)
       security:
@@ -598,8 +598,24 @@ paths:
                 recommendedRestock: 32
                 simulatedFallback: false
                 generatedAt: '2026-03-25T08:00:00.000Z'
+        '400':
+          description: itemId invalide (non numérique)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Invalid itemId
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          description: Historique insuffisant pour calculer une prédiction (< 7 jours de consommation)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Insufficient history to compute a prediction for this item
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/src/api/controllers/StockPredictionController.ts
+++ b/src/api/controllers/StockPredictionController.ts
@@ -55,6 +55,13 @@ export class StockPredictionController {
         `getItemPrediction itemId=${itemId} simulatedFallback=${prediction.simulatedFallback} cached=${existing !== null}`
       );
 
+      if (prediction.simulatedFallback) {
+        res
+          .status(404)
+          .json({ error: 'Insufficient history to compute a prediction for this item' });
+        return;
+      }
+
       res.status(HTTP_CODE_OK).json(prediction);
     } catch (err) {
       rootException(err as Error);

--- a/tests/api/controllers/StockPredictionController.test.ts
+++ b/tests/api/controllers/StockPredictionController.test.ts
@@ -164,8 +164,8 @@ describe('StockPredictionController', () => {
     });
 
     describe('no cached prediction', () => {
-      it('should compute and return 200 when no prediction is cached', async () => {
-        const computed = makePrediction({ simulatedFallback: true });
+      it('should compute and return 200 when history is sufficient', async () => {
+        const computed = makePrediction({ simulatedFallback: false });
         mockPredictionRepository.getLatest.mockResolvedValue(null);
         mockPredictionService.computeAndSave.mockResolvedValue(computed);
 
@@ -182,7 +182,7 @@ describe('StockPredictionController', () => {
       });
 
       it('should use default quantity=0 and minimumStock=1 when not provided', async () => {
-        const computed = makePrediction();
+        const computed = makePrediction({ simulatedFallback: false });
         mockPredictionRepository.getLatest.mockResolvedValue(null);
         mockPredictionService.computeAndSave.mockResolvedValue(computed);
 
@@ -191,6 +191,35 @@ describe('StockPredictionController', () => {
         await controller.getItemPrediction(req as Request, res);
 
         expect(mockPredictionService.computeAndSave).toHaveBeenCalledWith(3, 0, 1);
+      });
+
+      it('should return 404 when history is insufficient (simulatedFallback)', async () => {
+        const fallback = makePrediction({ simulatedFallback: true });
+        mockPredictionRepository.getLatest.mockResolvedValue(null);
+        mockPredictionService.computeAndSave.mockResolvedValue(fallback);
+
+        req = { params: { itemId: '4' }, query: {} };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({
+          error: 'Insufficient history to compute a prediction for this item',
+        });
+      });
+    });
+
+    describe('cached prediction with simulatedFallback', () => {
+      it('should return 404 when the cached prediction is a simulated fallback', async () => {
+        const cached = makePrediction({ simulatedFallback: true });
+        mockPredictionRepository.getLatest.mockResolvedValue(cached);
+
+        req = { params: { itemId: '1' }, query: {} };
+
+        await controller.getItemPrediction(req as Request, res);
+
+        expect(mockPredictionService.computeAndSave).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(404);
       });
     });
 


### PR DESCRIPTION
## Couches DDD impactées

- `src/api/controllers/` — StockPredictionController
- `tests/api/controllers/` — StockPredictionController.test.ts

## Changements

Ajout d'une vérification sur `prediction.simulatedFallback` dans `getItemPrediction` :
- `simulatedFallback: false` → 200 avec les données (comportement inchangé)
- `simulatedFallback: true` → 404 `{ error: 'Insufficient history to compute a prediction for this item' }`

Couvre les deux cas : prédiction fraîchement calculée ET prédiction cachée en fallback.

## Test plan

- [x] Prédiction réelle (simulatedFallback: false) → 200 ✅
- [x] Calcul avec historique insuffisant (simulatedFallback: true) → 404 ✅
- [x] Prédiction cachée en fallback → 404 ✅
- [x] 12 tests, tous verts

Closes #196