### PR TITLE
fix(ci): queue concurrent deploys and upgrade to webapps-deploy@v3 — closes #222

### DIFF
--- a/.github/workflows/main_stockhub-back.yml
+++ b/.github/workflows/main_stockhub-back.yml
@@ -154,6 +154,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
       - continuous-integration
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false # Les déploiements font la queue pour éviter les 409
     environment:
       name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
@@ -178,7 +181,7 @@ jobs:
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: 'stockhub-back'
           slot-name: 'Production'


### PR DESCRIPTION
## Résumé

- Ajout `concurrency: group: production-deploy, cancel-in-progress: false` sur le job `build-and-deploy` → les déploiements font la queue au lieu de se chevaucher
- Upgrade `azure/webapps-deploy@v2` → `v3` (meilleure gestion des timeouts et conflits)

## Cause du 409

Deux merges en succession rapide sur `main` (Release Please + notre PR) ont déclenché deux jobs `build-and-deploy` simultanément. Azure App Service Kudu retourne un `409 Conflict` quand un déploiement ZIP est déjà en cours sur le slot.

## Couches impactées

- `.github/workflows/main_stockhub-back.yml` (CI/CD uniquement)

## Test plan

- [ ] Merger deux PRs en succession rapide sur main et vérifier que le second attend le premier
- [ ] Vérifier que le déploiement Azure aboutit sans 409

Closes #222