### PR TITLE
chore(readme): replace static version badge with dynamic package-json badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI/CD Pipeline](https://github.com/sandrineCipolla/stockhub_back/actions/workflows/main_stockhub-back.yml/badge.svg)
 ![Security Audit](https://github.com/SandrineCipolla/stockhub_back/actions/workflows/security-audit.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-2.10.0-blue)
+![Version](https://img.shields.io/github/package-json/v/SandrineCipolla/stockhub_back)
 ![Node](https://img.shields.io/badge/node-22.x-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)
 [![Coverage](https://codecov.io/gh/SandrineCipolla/stockhub_back/branch/main/graph/badge.svg)](https://codecov.io/gh/SandrineCipolla/stockhub_back)

--- a/docs/ROADMAP-GLOBAL.md
+++ b/docs/ROADMAP-GLOBAL.md
@@ -1,0 +1,288 @@
+# Roadmap Globale StockHub — RNCP7 (mars 2027)
+
+> Dernière mise à jour : avril 2026
+> Couvre les 3 repositories : `stockhub_back`, `stockHub_V2_front`, `stockhub_design_system`
+
+---
+
+## Planning macro
+
+```
+Mai – Juin 2026     │ Phase 1 — Finitions V2 (bugs, clean code, CI)
+Juil – Sept 2026    │ Phase 2 — Features domaine + documentation RNCP
+Octobre 2026        │ Phase 3 — Bloc IA (études + premières implémentations)
+Novembre 2026       │ ✅ CHECKPOINT — "Est-ce démontrable ?"
+Nov – Déc 2026      │ Phase 3 suite — Finalisation IA + polish
+Janvier 2027        │ ⚡ SOUTENANCE BLANCHE
+Fév – Mars 2027     │ Phase 4 — Corrections post-blanche + démo finale
+Mars 2027           │ 🎓 SOUTENANCE
+```
+
+---
+
+## Phase 1 — Finitions V2 (mai – juin 2026)
+
+### Objectif
+
+Corriger les bugs visibles, solidifier la CI, finir les endpoints manquants. Rien qui puisse faire douter un jury.
+
+### Back — `stockhub_back`
+
+| #    | Ticket                                                                                                                 | Estimation |
+| ---- | ---------------------------------------------------------------------------------------------------------------------- | ---------- |
+| #191 | `GET /stocks/:id/items/:itemId` — endpoint détail item                                                                 | 2-3h       |
+| #169 | Category enum → free-text                                                                                              | 3-4h       |
+| #158 | Champ `note` libre sur les items                                                                                       | 2-3h       |
+| #219 | Validation Zod sur les inputs controllers                                                                              | 5-7h       |
+| #207 | Extraire fixtures inline → `tests/fixtures/`                                                                           | 2-3h       |
+| #209 | Améliorer branch coverage (handlers)                                                                                   | 3-5h       |
+| #214 | Integration tests job en CI (TestContainers)                                                                           | 4-6h       |
+| #225 | Branch protection rules sur `main`                                                                                     | 30min      |
+| —    | Spike: stratégie cron sur Azure F1 (Azure Function vs endpoint protégé + GH Actions schedule) — trancher avant Phase 2 | 1h         |
+| —    | Badge coverage dans README back (Codecov déjà branché)                                                                 | 15min      |
+
+### Front — `stockHub_V2_front`
+
+| #    | Ticket                                                                                                   | Estimation      |
+| ---- | -------------------------------------------------------------------------------------------------------- | --------------- |
+| #30  | fix: Vercel optionalDependencies (P1 bug) — **à diagnostiquer** (~30min-1h une fois la cause identifiée) | à diagnostiquer |
+| #138 | fix: landing — cloche notif + copyright (bug visible)                                                    | 1h              |
+| #51  | fix(a11y): score 86 → 95+ (4 issues critiques)                                                           | 4-6h            |
+| #23  | tech-debt: type safety post-merge conflicts                                                              | 3-4h            |
+| #38  | tech-debt: type assertions restantes (stockId)                                                           | 2-3h            |
+
+### Design System — `stockhub_design_system`
+
+| #   | Ticket                                           | Estimation |
+| --- | ------------------------------------------------ | ---------- |
+| #27 | fix: contraste bouton ghost light mode (WCAG AA) | 1-2h       |
+| #33 | fix: label-content-name-mismatch sur sh-header   | 1h         |
+| #34 | fix: button-name sur sh-button Shadow DOM        | 1h         |
+| #24 | Upgrade Node 22 + Storybook v10                  | 3-5h       |
+
+**Total phase 1 : ~4-5 semaines**
+
+---
+
+## Phase 2 — Features domaine + documentation RNCP (juil – sept 2026)
+
+### Objectif
+
+Ajouter des fonctionnalités métier démontrables et constituer la documentation RNCP (veille techno, ADRs, RGPD). Ce que
+le jury lira avant même de voir le code.
+
+### Back — `stockhub_back`
+
+| #    | Ticket                                                  | Estimation | Notes                                                                                                                                                       |
+| ---- | ------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #135 | Recalcul quotidien prédictions                          | 5-7h       | Stratégie tranchée en Phase 1 (spike) — Azure Function ou endpoint `/admin/predictions/recalculate` + GH Actions schedule. Documenter le choix dans un ADR. |
+| #133 | Suivi péremption (`openedAt`, `ProductType`)            | 7-9h       | —                                                                                                                                                           |
+| #36  | Refactoring visualization — symétrie CQRS               | 4-5h       | —                                                                                                                                                           |
+| #138 | Registre RGPD (`docs/rgpd.md`)                          | 3-4h       | —                                                                                                                                                           |
+| #224 | Procédure rollback (`docs/ci-cd/ROLLBACK-PROCEDURE.md`) | 1-2h       | —                                                                                                                                                           |
+| #131 | Audit et réconciliation ADRs wiki                       | 2-3h       | —                                                                                                                                                           |
+
+### Front — `stockHub_V2_front`
+
+| #    | Ticket                                              | Estimation | Dépend de |
+| ---- | --------------------------------------------------- | ---------- | --------- |
+| #142 | Afficher et éditer la note libre d'un article       | 3-4h       | Back #158 |
+| #144 | Custom category input + autocomplete                | 3-4h       | Back #169 |
+| #165 | Items en cards sur mobile                           | 3-4h       | Back #191 |
+| #61  | Confirmation modal avant suppression stock          | 2-3h       | —         |
+| #90  | Veille techno — sources et pratiques (RNCP Ce2.3.1) | 4-6h       | —         |
+| #4   | RNCP Checklist suivi — mise à jour                  | 2-3h       | —         |
+| #59  | Tests: fix useStocks après intégration backend      | 2-3h       | —         |
+| #35  | Tests: couverture utils + composants IA             | 3-5h       | —         |
+
+### Design System — `stockhub_design_system`
+
+| #   | Ticket                                        | Estimation |
+| --- | --------------------------------------------- | ---------- |
+| #13 | Audit responsive général tous composants      | 4-6h       |
+| #15 | Setup infrastructure tests (@open-wc/testing) | 3-4h       |
+| #16 | Tests unitaires sh-button, sh-stock-card      | 3-5h       |
+| #20 | Audit et nettoyage design tokens hardcodés    | 3-4h       |
+
+**Total phase 2 : ~5-6 semaines**
+
+---
+
+## Phase 3 — Bloc IA (oct – déc 2026)
+
+### Objectif
+
+Implémenter le bloc IA pour la certification RNCP7. C'est la pièce maîtresse de la soutenance.
+
+### MVP IA minimal garanti pour le checkpoint novembre
+
+> **Seul #139 (Page Suggestions) doit être déployé au checkpoint.**
+> Il s'appuie sur le service LLM OpenRouter/Mistral déjà en place (N2) — pas besoin d'attendre #152–#156.
+> #170 (shopping list AI) est un bonus de décembre si la Phase 3 avance bien.
+
+### Clarification sur #139
+
+`#139 Page Suggestions 'Que faire avec ce que j'ai ?'` s'appuie sur le **service LLM N2 existant** (OpenRouter/Mistral
+via `OpenRouterAIService` + `getCachedAISuggestions`). Ce backend est déjà en prod. Pas de nouveau ticket back requis
+pour débloquer #139.
+
+### Ordre impératif (dépendances entre repos)
+
+```
+Back: études (#148, #149, #150)
+        ↓
+Back: Prisma Recipe (#152) + ShoppingList (#153)
+        ↓
+Back: CRUD SavedProject (#156)
+        ↓
+Back: AI Shopping list generation (#170) → Front: Shopping list UI (#140) + Bibliothèque projets (#141)
+
+En parallèle dès octobre :
+Front: Page Suggestions IA (#139) ← back LLM N2 déjà disponible  ← MVP checkpoint novembre
+```
+
+### Back — `stockhub_back`
+
+| #    | Ticket                                            | Estimation | Ordre         |
+| ---- | ------------------------------------------------- | ---------- | ------------- |
+| #148 | Étude prompts IA par catégorie                    | 3-4h       | 1             |
+| #149 | Modélisation Recipe / ShoppingList / SavedProject | 3-4h       | 1             |
+| #150 | Étude function calling vs JSON mode               | 2-3h       | 1             |
+| #152 | Migration + modèle Prisma `Recipe`                | 3-5h       | 2             |
+| #153 | Migration + modèle Prisma `ShoppingList`          | 3-5h       | 3             |
+| #156 | CRUD SavedProject DDD/CQRS                        | 9-12h      | 4             |
+| #170 | AI shopping list generation                       | 9-12h      | 5 — bonus déc |
+
+### Front — `stockHub_V2_front`
+
+| #    | Ticket                                              | Estimation | Dépend de              | Priorité         |
+| ---- | --------------------------------------------------- | ---------- | ---------------------- | ---------------- |
+| #139 | Page Suggestions 'Que faire avec ce que j'ai ?'     | 6-8h       | Back LLM N2 (dispo)    | **MVP novembre** |
+| #140 | Page liste d'approvisionnement (générée + éditable) | 7-9h       | Back #170              | Bonus déc        |
+| #141 | Bibliothèque projets sauvegardés                    | 6-8h       | Back #156              | Bonus déc        |
+| #145 | Shopping list UI — générer, afficher, exporter      | 5-7h       | Back #153              | Bonus déc        |
+| #143 | Gestion et filtrage tags libres                     | 4-5h       | Back #159 (hors scope) | Hors scope       |
+
+### Design System — `stockhub_design_system`
+
+| #   | Ticket                    | Estimation |
+| --- | ------------------------- | ---------- |
+| #17 | Ajuster padding bouton md | 1h         |
+
+> #26 (`sh-feature-card`) déplacé en hors scope — la landing page n'est pas une priorité soutenance.
+
+**Total phase 3 : ~8-10 semaines**
+
+---
+
+## ✅ Checkpoint novembre 2026 — "Est-ce démontrable ?"
+
+**Date cible : début novembre 2026**
+
+Ce checkpoint existe pour éviter de découvrir en janvier qu'il manque un livrable. C'est une mini-soutenance à blanc
+entre soi.
+
+### Liste de vérification
+
+#### Fonctionnel
+
+- [ ] Flow complet authentification → CRUD stocks/items fonctionne en prod
+- [ ] **#139 Page Suggestions IA déployée** (MVP IA minimal garanti)
+- [ ] Prédictions ML visibles et correctes
+- [ ] Rôles collaborateurs fonctionnels (OWNER / EDITOR / VIEWER)
+
+#### Qualité
+
+- [ ] Score a11y ≥ 95 (Lighthouse)
+- [ ] Couverture tests back ≥ 85% statements
+- [ ] E2E stables sur le flow principal
+- [ ] 0 CVE high/critical (`npm audit --audit-level=high`)
+
+#### Documentation
+
+- [ ] Tous les ADRs à jour dans le wiki
+- [ ] Veille techno rédigée (front #90)
+- [ ] RGPD documenté (back #138)
+- [ ] OpenAPI à jour
+
+#### Infrastructure
+
+- [ ] Staging déployé et stable
+- [ ] Prod déployée et stable
+- [ ] Rollback procedure documentée (back #224)
+- [ ] Branch protection active (back #225)
+
+### Si le checkpoint révèle des manques
+
+- **Fonctionnel manquant** → reprioriser immédiatement, décaler Phase 3 bonus si nécessaire
+- **Documentation manquante** → sprint dédié docs en novembre
+- **Qualité insuffisante** → ne pas démarrer de nouvelles features avant d'avoir corrigé
+
+---
+
+## ⚡ Soutenance blanche — janvier 2027
+
+**Date cible : mi-janvier 2027**
+
+Simulation complète de la soutenance devant un pair ou un mentor.
+
+### Préparer avant la blanche
+
+- [ ] Back #205 — SonarCloud (si temps disponible)
+- [ ] Back #125 — compte démo dédié avec données réalistes
+- [ ] Front #43 — RNCP checklist synchronisée
+- [ ] Wiki complet (Backend-Guide, Architecture, ADRs, CICD)
+- [ ] Support de démonstration préparé
+
+### Après la blanche
+
+Utiliser le retour pour corriger les points soulevés pendant les 6 semaines restantes (fév – mars 2027).
+
+---
+
+## Phase 4 — Corrections + démo finale (fév – mars 2027)
+
+**Pas de nouvelles features.** Uniquement :
+
+- Corrections identifiées à la blanche
+- Polish UX si critique
+- Répétition de la démonstration
+- Vérification déploiement prod la veille
+
+---
+
+## Corrélations entre repos
+
+| Feature             | Back              | Front             | DS               |
+| ------------------- | ----------------- | ----------------- | ---------------- |
+| Note sur items      | #158              | #142              | —                |
+| Category free-text  | #169              | #144              | —                |
+| Tags libres         | #159 (hors scope) | #143 (hors scope) | —                |
+| Item détail         | #191              | #165              | —                |
+| Suggestions IA      | LLM N2 existant   | #139              | —                |
+| Shopping list       | #153 + #170       | #140 + #145       | —                |
+| Projets sauvegardés | #156              | #141              | —                |
+| Notification panel  | #64 (hors scope)  | #163 (hors scope) | —                |
+| Landing visuelle    | —                 | #121 (hors scope) | #26 (hors scope) |
+| A11y                | —                 | #51               | #27 #33 #34      |
+
+---
+
+## Hors scope (post-soutenance)
+
+| Repo  | #    | Titre                                     |
+| ----- | ---- | ----------------------------------------- |
+| Back  | #64  | Notifications SSE/WebSockets              |
+| Back  | #65  | Audit log, analytics avancés              |
+| Back  | #159 | Tags libres many-to-many                  |
+| Front | #143 | Gestion tags libres (dépend de back #159) |
+| Front | #163 | Notification panel                        |
+| Front | #121 | Aperçus visuels landing                   |
+| Front | #28  | Setup E2E Playwright complet              |
+| Front | #66  | E2E complets front + back                 |
+| Front | #101 | Playwright auth interactive               |
+| DS    | #26  | sh-feature-card                           |
+
+---
+
+> Revoir ce document à chaque début de phase et après la soutenance blanche.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,147 @@
+# Roadmap StockHub Back — v2 → soutenance RNCP7 (mars 2027)
+
+> Dernière mise à jour : avril 2026
+> Horizon : ~11 mois
+
+---
+
+## Vue d'ensemble
+
+| Phase                          | Période          | Focus                                      |
+| ------------------------------ | ---------------- | ------------------------------------------ |
+| **Phase 1** — Finitions V2     | Mai – Juin 2026  | Endpoints manquants, clean code, CI solide |
+| **Phase 2** — Features domaine | Juil – Sept 2026 | Nouvelles fonctionnalités métier           |
+| **Phase 3** — IA & données     | Oct – Déc 2026   | Bloc IA RNCP, ShoppingList, Recipe         |
+| **Phase 4** — Soutenance       | Jan – Mars 2027  | Documentation, polish, démo                |
+
+---
+
+## Phase 1 — Finitions V2 (mai – juin 2026)
+
+### Objectif
+
+Compléter l'API V2 sur les points manquants, fiabiliser la CI, résorber la dette technique accumulée.
+
+| #    | Ticket                                                           | Estimation | Priorité |
+| ---- | ---------------------------------------------------------------- | ---------- | -------- |
+| #191 | `GET /stocks/:stockId/items/:itemId` — endpoint détail item      | 2-3h       | 🔴       |
+| #169 | Remplacer l'enum category par un champ free-text                 | 3-4h       | 🔴       |
+| #158 | Ajouter un champ `note` libre sur les items                      | 2-3h       | 🔴       |
+| #219 | Validation Zod sur les inputs controllers (ADR + implémentation) | 5-7h       | 🔴       |
+| #207 | Extraire les fixtures inline vers `tests/fixtures/`              | 2-3h       | 🟡       |
+| #209 | Améliorer la branch coverage (handlers, controllers)             | 3-5h       | 🟡       |
+| #214 | Ajouter un job integration tests à la CI (TestContainers)        | 4-6h       | 🟡       |
+| #225 | Branch protection rules sur `main` (GitHub Settings)             | 30min      | 🟡       |
+
+**Total estimé : ~3-4 semaines à temps partiel**
+
+---
+
+## Phase 2 — Features domaine (juil – sept 2026)
+
+### Objectif
+
+Enrichir le modèle métier avec des fonctionnalités qui démontrent la maîtrise DDD/CQRS et la profondeur du domain model.
+
+| #    | Ticket                                                                | Estimation | Priorité |
+| ---- | --------------------------------------------------------------------- | ---------- | -------- |
+| #135 | Cron job — recalcul quotidien des prédictions IA                      | 5-7h       | 🔴       |
+| #133 | Suivi péremption avancé (`openedAt`, `ProductType` générique)         | 7-9h       | 🔴       |
+| #36  | Refactoring visualization — symétrie CQRS avec manipulation           | 4-5h       | 🟡       |
+| #126 | Spike faisabilité scan code-barres (ajout auto d'articles)            | 4-6h       | 🟡       |
+| #131 | Audit et réconciliation des ADRs dans le wiki                         | 2-3h       | 🟡       |
+| #138 | Registre des traitements RGPD (`docs/rgpd.md`)                        | 3-4h       | 🟡       |
+| #224 | Procédure de rollback production (`docs/ci-cd/ROLLBACK-PROCEDURE.md`) | 1-2h       | 🟡       |
+
+**Total estimé : ~4-5 semaines à temps partiel**
+
+---
+
+## Phase 3 — IA & données (oct – déc 2026)
+
+### Objectif
+
+Implémenter le bloc IA complet pour la certification RNCP7 (Bloc 2 — Solutions IA). C'est la partie la plus ambitieuse et la plus valorisante pour la soutenance.
+
+### Ordre impératif (dépendances)
+
+```
+#148 Étude prompts IA          ─┐
+#149 Modélisation données       ├─→ #152 Prisma Recipe ─→ #153 Prisma ShoppingList ─→ #156 CRUD SavedProject ─→ #170 AI Shopping list
+#150 Étude function calling    ─┘
+```
+
+| #    | Ticket                                                         | Estimation | Notes        |
+| ---- | -------------------------------------------------------------- | ---------- | ------------ |
+| #148 | Étude prompts système pour suggestions IA par catégorie        | 3-4h       | Avant tout   |
+| #149 | Modélisation données Recipe / SavedProject / ShoppingList      | 3-4h       | Avant tout   |
+| #150 | Étude function calling vs JSON mode pour AIService             | 2-3h       | Avant tout   |
+| #152 | Migration + modèle Prisma `Recipe` + `RecipeIngredient`        | 3-5h       | Après études |
+| #153 | Migration + modèle Prisma `ShoppingList` + `ShoppingListItem`  | 3-5h       | Après #152   |
+| #156 | CRUD `SavedProject` — domain + infrastructure + api (DDD/CQRS) | 9-12h      | Après #153   |
+| #170 | AI shopping list generation avec sélection contextuelle        | 9-12h      | Après #156   |
+
+**Total estimé : ~6-8 semaines à temps partiel**
+
+---
+
+## Phase 4 — Soutenance (jan – mars 2027)
+
+### Objectif
+
+Préparer la démonstration, finaliser la documentation, s'assurer que tout est propre et déployé.
+
+| #    | Ticket                                                        | Estimation   | Notes                 |
+| ---- | ------------------------------------------------------------- | ------------ | --------------------- |
+| #205 | Étude SonarCloud — qualité de code                            | 3-4h         | Optionnel selon temps |
+| #125 | Compte démo dédié pour le seed de démonstration               | 3-5h         | Avant démo            |
+| —    | Mise à jour wiki complète (Backend-Guide, ADRs, Architecture) | 2-3h         | Avant soutenance      |
+| —    | Vérification déploiement prod + staging                       | 1h           | Avant soutenance      |
+| —    | Préparation support de démonstration                          | selon besoin | —                     |
+
+**Tickets hors scope soutenance (à traiter après ou jamais)**
+
+| #    | Ticket                       | Raison                              |
+| ---- | ---------------------------- | ----------------------------------- |
+| #64  | Notifications SSE/WebSockets | P4, pas de frontend consommateur    |
+| #65  | Audit log, analytics avancés | P4, scope trop large                |
+| #159 | Tags libres many-to-many     | Complexité élevée, valeur marginale |
+
+---
+
+## Résumé par ticket
+
+| #    | Titre court                      | Phase | Estimation |
+| ---- | -------------------------------- | ----- | ---------- |
+| #36  | Refactoring visualization CQRS   | 2     | 4-5h       |
+| #125 | Compte démo dédié                | 4     | 3-5h       |
+| #126 | Spike scan code-barres           | 2     | 4-6h       |
+| #131 | Audit ADRs wiki                  | 2     | 2-3h       |
+| #133 | Suivi péremption avancé          | 2     | 7-9h       |
+| #135 | Cron recalcul prédictions        | 2     | 5-7h       |
+| #138 | RGPD registre traitements        | 2     | 3-4h       |
+| #148 | Étude prompts IA                 | 3     | 3-4h       |
+| #149 | Modélisation Recipe/ShoppingList | 3     | 3-4h       |
+| #150 | Étude function calling vs JSON   | 3     | 2-3h       |
+| #152 | Prisma Recipe                    | 3     | 3-5h       |
+| #153 | Prisma ShoppingList              | 3     | 3-5h       |
+| #156 | CRUD SavedProject                | 3     | 9-12h      |
+| #158 | Champ note sur items             | 1     | 2-3h       |
+| #159 | Tags libres (hors scope)         | —     | —          |
+| #169 | Category free-text               | 1     | 3-4h       |
+| #170 | AI shopping list                 | 3     | 9-12h      |
+| #191 | GET item individuel              | 1     | 2-3h       |
+| #205 | Étude SonarCloud                 | 4     | 3-4h       |
+| #207 | Extraire fixtures inline         | 1     | 2-3h       |
+| #209 | Branch coverage                  | 1     | 3-5h       |
+| #214 | Integration tests CI             | 1     | 4-6h       |
+| #219 | Zod validation                   | 1     | 5-7h       |
+| #224 | Rollback procedure               | 2     | 1-2h       |
+| #225 | Branch protection                | 1     | 30min      |
+| #64  | SSE/WebSockets (hors scope)      | —     | —          |
+| #65  | Audit log (hors scope)           | —     | —          |
+
+---
+
+> Ce planning est indicatif. Les estimations supposent des sessions de travail focalisées sans interruption.
+> Revoir les priorités à chaque début de phase selon l'avancement du frontend et les retours de la soutenance blanche.


### PR DESCRIPTION
## Résumé

- Remplace le badge version statique (hardcodé, toujours en retard) par un badge dynamique shields.io qui lit directement le \`package.json\`
- Ajoute \`docs/ROADMAP.md\` et \`docs/ROADMAP-GLOBAL.md\` (planning soutenance RNCP7)

## Pourquoi

Le badge statique affichait \`2.10.0\` alors qu'on est en \`2.10.1\`. Le badge dynamique reflète la version réelle en temps réel.

## Couches impactées

- \`README.md\`
- \`docs/\` (roadmap docs)

## Test plan

- [ ] Vérifier que le badge version affiche bien \`2.10.1\` après merge

Closes #198