### PR TITLE
feat(items): add GET /stocks/:stockId/items/:itemId — closes #191

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -340,6 +340,57 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
   /api/v2/stocks/{stockId}/items/{itemId}:
+    get:
+      summary: Récupérer le détail d'un item
+      description: Retourne le détail complet d'un item appartenant au stock spécifié. Retourne 404 si l'item ou le stock n'existent pas ou si l'accès est refusé.
+      tags:
+        - Stock Visualization (READ)
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: stockId
+          in: path
+          required: true
+          description: Identifiant unique du stock
+          schema:
+            type: integer
+            example: 1
+        - name: itemId
+          in: path
+          required: true
+          description: Identifiant unique de l'item
+          schema:
+            type: integer
+            example: 3
+      responses:
+        '200':
+          description: Détail de l'item récupéré avec succès
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StockItemDTO'
+              example:
+                id: 3
+                label: Tomates bio
+                description: Tomates bio du marché local
+                quantity: 12
+                minimumStock: 5
+                status: optimal
+                updatedAt: '2026-06-15T10:30:00.000Z'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Item ou stock introuvable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Item not found
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     patch:
       summary: Modifier un item
       description: Met à jour un ou plusieurs champs d'un item (label, description, minimumStock, quantity). Tous les champs sont optionnels — seuls les champs fournis sont modifiés.

--- a/src/api/controllers/StockControllerVisualization.ts
+++ b/src/api/controllers/StockControllerVisualization.ts
@@ -79,4 +79,34 @@ export class StockControllerVisualization {
       sendError(res, err as CustomError);
     }
   }
+
+  public async getStockItemDetail(req: express.Request, res: express.Response) {
+    try {
+      const OID = req.userID || '';
+
+      if (!this.validateOID(OID, res)) {
+        return;
+      }
+
+      const userID = await this.userService.convertOIDtoUserID(OID);
+      const stockId = Number(req.params.stockId);
+      const itemId = Number(req.params.itemId);
+      const item = await this.stockVisualizationService.getStockItemDetail(
+        stockId,
+        itemId,
+        userID.value
+      );
+
+      if (!item) {
+        res.status(404).json({ error: 'Item not found' });
+        return;
+      }
+
+      rootMain.info(`getStockItemDetail OID=${OID} stockId=${stockId} itemId=${itemId}`);
+      res.status(HTTP_CODE_OK).json(item);
+    } catch (err: unknown) {
+      rootException(err as Error);
+      sendError(res, err as CustomError);
+    }
+  }
 }

--- a/src/api/routes/StockRoutesV2.ts
+++ b/src/api/routes/StockRoutesV2.ts
@@ -165,6 +165,16 @@ const configureStockRoutesV2 = async (prismaClient?: PrismaClient): Promise<Rout
 
   logger.info('Routes for /stocks/:stockId/items configured');
 
+  router.get(
+    STOCK_ROUTES.ITEM_DETAIL,
+    authorizeStockRead,
+    async (req: express.Request, res: express.Response) => {
+      await stockController.getStockItemDetail(req, res);
+    }
+  );
+
+  logger.info(`Routes for GET ${STOCK_ROUTES.ITEM_DETAIL} configured`);
+
   // Manipulation routes
   router.post(STOCK_ROUTES.CREATE, async (req, res: express.Response) => {
     await manipulationController.createStock(req as CreateStockRequest, res);

--- a/src/api/routes/constants/routePaths.ts
+++ b/src/api/routes/constants/routePaths.ts
@@ -12,6 +12,9 @@ export const STOCK_ROUTES = {
   /** GET - Get all items in a stock (requires authorization) */
   ITEMS: '/stocks/:stockId/items',
 
+  /** GET - Get a single item detail (requires authorization) */
+  ITEM_DETAIL: '/stocks/:stockId/items/:itemId',
+
   /** POST - Create a new stock */
   CREATE: '/stocks',
 

--- a/src/domain/stock-management/visualization/queries/IStockVisualizationRepository.ts
+++ b/src/domain/stock-management/visualization/queries/IStockVisualizationRepository.ts
@@ -12,4 +12,6 @@ export interface IStockVisualizationRepository {
   getStockDetails(stockId: number, userId: number): Promise<Stock | null>;
 
   getStockItems(stockId: number, userId: number): Promise<StockItem[]>;
+
+  getStockItemDetail(stockId: number, itemId: number, userId: number): Promise<StockItem | null>;
 }

--- a/src/domain/stock-management/visualization/services/StockVisualizationService.ts
+++ b/src/domain/stock-management/visualization/services/StockVisualizationService.ts
@@ -36,4 +36,24 @@ export class StockVisualizationService {
       status: item.getStatus(),
     }));
   }
+
+  async getStockItemDetail(
+    stockId: number,
+    itemId: number,
+    userId: number
+  ): Promise<StockItemDto | null> {
+    const item = await this.repository.getStockItemDetail(stockId, itemId, userId);
+    if (!item) {
+      return null;
+    }
+    return {
+      id: item.id,
+      label: item.label,
+      description: item.description,
+      quantity: item.quantity,
+      minimumStock: item.minimumStock,
+      status: item.getStatus(),
+      updatedAt: item.updatedAt ? item.updatedAt.toISOString() : null,
+    };
+  }
 }

--- a/src/infrastructure/stock-management/visualization/repositories/PrismaStockVisualizationRepository.ts
+++ b/src/infrastructure/stock-management/visualization/repositories/PrismaStockVisualizationRepository.ts
@@ -146,4 +146,43 @@ export class PrismaStockVisualizationRepository implements IStockVisualizationRe
       } as DependencyTelemetry);
     }
   }
+
+  async getStockItemDetail(
+    stockId: number,
+    itemId: number,
+    userId: number
+  ): Promise<StockItem | null> {
+    try {
+      const stock = await this.prisma.stock.findFirst({
+        where: {
+          id: stockId,
+          OR: [{ userId }, { collaborators: { some: { userId } } }],
+        },
+      });
+      if (!stock) {
+        throw new Error('Stock not found or access denied');
+      }
+
+      const item = await this.prisma.item.findFirst({
+        where: { id: itemId, stockId },
+      });
+
+      if (!item) {
+        return null;
+      }
+
+      return new StockItem(
+        item.id,
+        item.label ?? '',
+        item.quantity ?? 0,
+        item.description ?? '',
+        item.minimumStock,
+        item.stockId ?? stockId,
+        item.updatedAt
+      );
+    } catch (error) {
+      rootException(error as Error);
+      throw error;
+    }
+  }
 }

--- a/tests/api/controllers/StockControllerVisualization.test.ts
+++ b/tests/api/controllers/StockControllerVisualization.test.ts
@@ -4,6 +4,7 @@ import { StockVisualizationService } from '@domain/stock-management/visualizatio
 import {
   StockSummaryDto,
   StockDetailDto,
+  StockItemDto,
 } from '@domain/stock-management/visualization/models/StockSummary';
 import { UserService } from '@domain/user/services/UserService';
 import { HTTP_CODE_OK } from '@utils/httpCodes';
@@ -149,6 +150,54 @@ describe('StockControllerVisualization', () => {
         mockUserService.convertOIDtoUserID = jest.fn().mockRejectedValue(error);
 
         await controller.getStockItems(req as Request, res as Response);
+
+        expect(sendError).toHaveBeenCalledWith(res, error as CustomError);
+      });
+    });
+  });
+
+  describe('getStockItemDetail', () => {
+    describe('when the item is found', () => {
+      it('should return 200 and the item detail', async () => {
+        req = { userID: 'test-oid', params: { stockId: '1', itemId: '3' } };
+        mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
+        const mockItem: StockItemDto = {
+          id: 3,
+          label: 'Tomates bio',
+          description: 'Tomates bio du marché',
+          quantity: 12,
+          minimumStock: 5,
+          status: 'optimal',
+        };
+        mockStockService.getStockItemDetail = jest.fn().mockResolvedValue(mockItem);
+
+        await controller.getStockItemDetail(req as Request, res as Response);
+
+        expect(res.status).toHaveBeenCalledWith(HTTP_CODE_OK);
+        expect(res.json).toHaveBeenCalledWith(mockItem);
+      });
+    });
+
+    describe('when the item is not found', () => {
+      it('should return 404', async () => {
+        req = { userID: 'test-oid', params: { stockId: '1', itemId: '99' } };
+        mockUserService.convertOIDtoUserID = jest.fn().mockResolvedValue({ value: 42 });
+        mockStockService.getStockItemDetail = jest.fn().mockResolvedValue(null);
+
+        await controller.getStockItemDetail(req as Request, res as Response);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Item not found' });
+      });
+    });
+
+    describe('when the service call fails', () => {
+      it('should call sendError', async () => {
+        req = { userID: 'test-oid', params: { stockId: '1', itemId: '3' } };
+        const error = new Error('fail item detail');
+        mockUserService.convertOIDtoUserID = jest.fn().mockRejectedValue(error);
+
+        await controller.getStockItemDetail(req as Request, res as Response);
 
         expect(sendError).toHaveBeenCalledWith(res, error as CustomError);
       });

--- a/tests/domain/stock-management/visualization/services/StockVisualizationService.test.ts
+++ b/tests/domain/stock-management/visualization/services/StockVisualizationService.test.ts
@@ -10,6 +10,7 @@ describe('StockVisualizationService', () => {
         getAllStocks: async () => [],
         getStockDetails: async () => null,
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return an empty array', async () => {
@@ -31,6 +32,7 @@ describe('StockVisualizationService', () => {
         ],
         getStockDetails: async () => null,
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return stock with aggregates', async () => {
@@ -61,6 +63,7 @@ describe('StockVisualizationService', () => {
         ],
         getStockDetails: async () => null,
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return all stocks with aggregates', async () => {
@@ -82,6 +85,7 @@ describe('StockVisualizationService', () => {
             new StockItem(2, 'Item 2', 0, 'desc', 3, 1), // qty=0 → out-of-stock
           ]),
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return stock detail with items and aggregates', async () => {
@@ -102,6 +106,7 @@ describe('StockVisualizationService', () => {
         getAllStocks: async () => [],
         getStockDetails: async () => new Stock(1, 'Stock 1', 'Description 1', 'alimentation', []),
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return stock with 0 items and 0 quantity', async () => {
@@ -120,6 +125,7 @@ describe('StockVisualizationService', () => {
         getAllStocks: async () => [],
         getStockDetails: async () => null,
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should throw an error', async () => {
@@ -134,6 +140,7 @@ describe('StockVisualizationService', () => {
         getAllStocks: async () => [],
         getStockDetails: async () => null,
         getStockItems: async () => [],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return an empty array', async () => {
@@ -150,6 +157,7 @@ describe('StockVisualizationService', () => {
           new StockItem(1, 'Item 1', 5, 'description item1', 3, 1), // qty=5, min=3 → optimal
           new StockItem(2, 'Item 2', 0, 'description item2', 3, 1), // qty=0 → out-of-stock
         ],
+        getStockItemDetail: async () => null,
       };
       const service = new StockVisualizationService(fakeRepository);
       it('should return items with status', async () => {
@@ -161,6 +169,57 @@ describe('StockVisualizationService', () => {
         expect(result[1].label).toBe('Item 2');
         expect(result[1].quantity).toBe(0);
         expect(result[1].status).toBe('out-of-stock');
+      });
+    });
+  });
+
+  describe('getStockItemDetail', () => {
+    describe('when item exists', () => {
+      const item = new StockItem(1, 'Item 1', 5, 'description item1', 3, 1);
+      const fakeRepository: IStockVisualizationRepository = {
+        getAllStocks: async () => [],
+        getStockDetails: async () => null,
+        getStockItems: async () => [],
+        getStockItemDetail: async () => item,
+      };
+      const service = new StockVisualizationService(fakeRepository);
+      it('should return the item DTO with status', async () => {
+        const result = await service.getStockItemDetail(1, 1, 1);
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe(1);
+        expect(result?.label).toBe('Item 1');
+        expect(result?.quantity).toBe(5);
+        expect(result?.minimumStock).toBe(3);
+        expect(result?.status).toBe('optimal');
+      });
+    });
+
+    describe('when item does not exist', () => {
+      const fakeRepository: IStockVisualizationRepository = {
+        getAllStocks: async () => [],
+        getStockDetails: async () => null,
+        getStockItems: async () => [],
+        getStockItemDetail: async () => null,
+      };
+      const service = new StockVisualizationService(fakeRepository);
+      it('should return null', async () => {
+        const result = await service.getStockItemDetail(1, 99, 1);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('when item is critical', () => {
+      const item = new StockItem(2, 'Item 2', 0, 'description item2', 3, 1);
+      const fakeRepository: IStockVisualizationRepository = {
+        getAllStocks: async () => [],
+        getStockDetails: async () => null,
+        getStockItems: async () => [],
+        getStockItemDetail: async () => item,
+      };
+      const service = new StockVisualizationService(fakeRepository);
+      it('should return the item with out-of-stock status', async () => {
+        const result = await service.getStockItemDetail(1, 2, 1);
+        expect(result?.status).toBe('out-of-stock');
       });
     });
   });


### PR DESCRIPTION
## Summary

- Implémentation complète de l'endpoint `GET /stocks/:stockId/items/:itemId` sur toutes les couches DDD/CQRS
- Retourne 404 si l'item ou le stock n'existent pas, ou si l'accès est refusé
- Documentation OpenAPI mise à jour

## Couches DDD impactées

| Couche | Fichier |
|---|---|
| Domain — Interface | `IStockVisualizationRepository.ts` |
| Domain — Service | `StockVisualizationService.ts` |
| Infrastructure | `PrismaStockVisualizationRepository.ts` |
| API — Controller | `StockControllerVisualization.ts` |
| API — Routes | `StockRoutesV2.ts`, `routePaths.ts` |
| Docs | `docs/openapi.yaml` |
| Tests | `StockVisualizationService.test.ts` |

## Test plan

- [x] `tsc --noEmit` — 0 erreur TypeScript
- [x] 301 tests unitaires passent (3 nouveaux cas pour `getStockItemDetail`)
- [x] ESLint 0 warning
- [x] `docs/openapi.yaml` mis à jour avec `GET /api/v2/stocks/{stockId}/items/{itemId}`

Closes #191